### PR TITLE
fix two typos of programing -> programming

### DIFF
--- a/src/content/1.2/Types and Functions.tex
+++ b/src/content/1.2/Types and Functions.tex
@@ -226,7 +226,7 @@ at running programs --- humans are not! If we were, we wouldn't need
 computers.
 
 But there is an alternative. It's called \newterm{denotational semantics}
-and it's based on math. In denotational semantics every programing
+and it's based on math. In denotational semantics every programming
 construct is given its mathematical interpretation. With that, if you
 want to prove a property of a program, you just prove a mathematical
 theorem. You might think that theorem proving is hard, but the fact is

--- a/src/content/3.4/Monads - Programmer's Definition.tex
+++ b/src/content/3.4/Monads - Programmer's Definition.tex
@@ -46,7 +46,7 @@ together. More precisely, it composes things.
 This partially explains the difficulties a lot of programmers,
 especially those coming from the imperative background, have with
 understanding the monad. The problem is that we are not used to thinking
-of programing in terms of function composition. This is understandable.
+of programming in terms of function composition. This is understandable.
 We often give names to intermediate values rather than pass them
 directly from function to function. We also inline short segments of
 glue code rather than abstract them into helper functions. Here's an


### PR DESCRIPTION
In some regions 'programing' is considered a correct spelling, but since the author uses 'programming' in all but two places I am assuming these two instances are typos.