### PR TITLE
convert part 2 to math

### DIFF
--- a/src/content/2.1/Declarative Programming.tex
+++ b/src/content/2.1/Declarative Programming.tex
@@ -10,13 +10,13 @@ You can see this even at the most basic level. Composition itself may be
 defined declaratively; as in, $h$ is a composite of $g$
 after $f$:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 h = g . f
 \end{Verbatim}
 or imperatively; as in, call $f$ first, remember the result of
 that call, then call $g$ with the result:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 h x = let y = f x 
       in g y
 \end{Verbatim}

--- a/src/content/2.2/Limits and Colimits.tex
+++ b/src/content/2.2/Limits and Colimits.tex
@@ -729,7 +729,7 @@ familiar reader functor. Its continuity means that, for instance, any
 function returning a product is equivalent to a product of functions; in
 particular:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 r -> (a, b) ~ (r -> a, r -> b)
 \end{Verbatim}
 I know what you're thinking: You don't need category theory to figure

--- a/src/content/2.3/Free Monoids.tex
+++ b/src/content/2.3/Free Monoids.tex
@@ -26,19 +26,19 @@ identify some of the pairs --- just enough to support the unit and
 associativity laws.
 
 Let's see how this works in a simple example. Let's start with a set of
-two elements, \code{\{a, b\}}. We'll call them the generators of the
-free monoid. First, we'll add a special element \code{e} to serve as
+two elements, $\{a, b\}$. We'll call them the generators of the
+free monoid. First, we'll add a special element $e$ to serve as
 the unit. Next we'll add all the pairs of elements and call them
-``products''. The product of \code{a} and \code{b} will be the pair
-\code{(a, b)}. The product of \code{b} and \code{a} will be the
-pair \code{(b, a)}, the product of \code{a} with \code{a} will be
-\code{(a, a)}, the product of \code{b} with \code{b} will be
-\code{(b, b)}. We can also form pairs with \code{e}, like
-\code{(a, e)}, \code{(e, b)}, etc., but we'll identify them with
-\code{a}, \code{b}, etc. So in this round we'll only add
-\code{(a, a)}, \code{(a, b)} and \code{(b, a)} and
-\code{(b, b)}, and end up with the set
-\code{\{e, a, b, (a, a), (a, b), (b, a), (b, b)\}}.
+``products''. The product of $a$ and $b$ will be the pair
+$(a, b)$. The product of $b$ and $a$ will be the
+pair $(b, a)$, the product of $a$ with $a$ will be
+$(a, a)$, the product of $b$ with $b$ will be
+$(b, b)$. We can also form pairs with $e$, like
+$(a, e)$, $(e, b)$, etc., but we'll identify them with
+$a$, $b$, etc. So in this round we'll only add
+$(a, a)$, $(a, b)$ and $(b, a)$ and
+$(b, b)$, and end up with the set
+$\{e, a, b, (a, a), (a, b), (b, a), (b, b)\}$.
 
 \begin{figure}[H]
 \centering
@@ -47,21 +47,21 @@ pair \code{(b, a)}, the product of \code{a} with \code{a} will be
 
 \noindent
 In the next round we'll keep adding elements like:
-\code{(a, (a, b))}, \code{((a, b), a)}, etc. At this point we'll
+$(a, (a, b))$, $((a, b), a)$, etc. At this point we'll
 have to make sure that associativity holds, so we'll identify
-\code{(a, (b, a))} with \code{((a, b), a)}, etc. In other words,
+$(a, (b, a))$ with $((a, b), a)$, etc. In other words,
 we won't be needing internal parentheses.
 
 You can guess what the final result of this process will be: we'll
-create all possible lists of \code{a}s and \code{b}s. In fact, if we
-represent \code{e} as an empty list, we can see that our
+create all possible lists of $a$s and $b$s. In fact, if we
+represent $e$ as an empty list, we can see that our
 ``multiplication'' is nothing but list concatenation.
 
 This kind of construction, in which you keep generating all possible
 combinations of elements, and perform the minimum number of
 identifications --- just enough to uphold the laws --- is called a free
 construction. What we have just done is to construct a \newterm{free
-monoid} from the set of generators \code{\{a, b\}}.
+monoid} from the set of generators $\{a, b\}$.
 
 \section{Free Monoid in Haskell}\label{free-monoid-in-haskell}
 
@@ -72,7 +72,7 @@ problems with infinite lists.)
 
 A monoid in Haskell is defined by the type class:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 class Monoid m where
     mempty :: m
     mappend :: m -> m -> m
@@ -86,7 +86,7 @@ monoid is instantiated.
 The fact that a list of any type forms a monoid is described by this
 instance definition:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 instance Monoid [a] where
     mempty = []
     mappend = (++)
@@ -99,7 +99,7 @@ with the set \code{a} serving as generators. The set of natural
 numbers with multiplication is not a free monoid, because we identify
 lots of products. Compare for instance:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 2 * 3 = 6
 [2] ++ [3] = [2, 3] // not the same as [6]
 \end{Verbatim}
@@ -128,43 +128,44 @@ structure-preserving functions are called \newterm{homomorphisms}. A monoid
 homomorphism must map the product of two elements to the product of the
 mapping of the two elements:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 h (a * b) = h a * h b
 \end{Verbatim}
+
 and it must map unit to unit.\\
 For instance, consider a homomorphism from lists of integers to
 integers. If we map \code{{[}2{]}} to 2 and \code{{[}3{]}} to 3, we
 have to map \code{{[}2, 3{]}} to 6, because concatenation
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 [2] ++ [3] = [2, 3]
 \end{Verbatim}
 becomes multiplication
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 2 * 3 = 6
 \end{Verbatim}
 Now let's forget about the internal structure of individual monoids, and
 only look at them as objects with corresponding morphisms. You get a
-category \textbf{Mon} of monoids.
+category $\cat{Mon}$ of monoids.
 
 Okay, maybe before we forget about internal structure, let us notice an
-important property. Every object of \textbf{Mon} can be trivially mapped
+important property. Every object of $\cat{Mon}$ can be trivially mapped
 to a set. It's just the set of its elements. This set is called the
 \newterm{underlying} set. In fact, not only can we map objects of
-\textbf{Mon} to sets, but we can also map morphisms of \textbf{Mon}
+$\cat{Mon}$ to sets, but we can also map morphisms of $\cat{Mon}$
 (homomorphisms) to functions. Again, this seems sort of trivial, but it
 will become useful soon. This mapping of objects and morphisms from
-\textbf{Mon} to $\Set$ is in fact a functor. Since this functor
+$\cat{Mon}$ to $\Set$ is in fact a functor. Since this functor
 ``forgets'' the monoidal structure --- once we are inside a plain set,
 we no longer distinguish the unit element or care about multiplication
 --- it's called a \newterm{forgetful functor}. Forgetful functors come up
 regularly in category theory.
 
-We now have two different views of \textbf{Mon}. We can treat it just
+We now have two different views of $\cat{Mon}$. We can treat it just
 like any other category with objects and morphisms. In that view, we
 don't see the internal structure of monoids. All we can say about a
-particular object in \textbf{Mon} is that it connects to itself and to
+particular object in $\cat{Mon}$ is that it connects to itself and to
 other objects through morphisms. The ``multiplication'' table of
 morphisms --- the composition rules --- are derived from the other view:
 monoids-as-sets. By going to category theory we haven't lost this view
@@ -182,21 +183,21 @@ That's where the forgetful functor comes into play. We can use it to
 X-ray our monoids. We can identify the generators in the X-ray images of
 those blobs. Here's how it works:
 
-We start with a set of generators, \code{x}. That's a set in
+We start with a set of generators, $x$. That's a set in
 $\Set$.
 
-The pattern we are going to match consists of a monoid \code{m} --- an
-object of \textbf{Mon} --- and a function \code{p} in $\Set$:
+The pattern we are going to match consists of a monoid $m$ --- an
+object of $\cat{Mon}$ --- and a function $p$ in $\Set$:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 p :: x -> U m
 \end{Verbatim}
-where \code{U} is our forgetful functor from \textbf{Mon} to
+where $U$ is our forgetful functor from $\cat{Mon}$ to
 $\Set$. This is a weird heterogeneous pattern --- half in
-\textbf{Mon} and half in $\Set$.
+$\cat{Mon}$ and half in $\Set$.
 
-The idea is that the function \code{p} will identify the set of
-generators inside the X-ray image of \code{m}. It doesn't matter that
+The idea is that the function $p$ will identify the set of
+generators inside the X-ray image of $m$. It doesn't matter that
 functions may be lousy at identifying points inside sets (they may
 collapse them). It will all be sorted out by the universal construction,
 which will pick the best representative of this pattern.
@@ -208,28 +209,28 @@ which will pick the best representative of this pattern.
 
 \noindent
 We also have to define the ranking among candidates. Suppose we have
-another candidate: a monoid \code{n} and a function that identifies
+another candidate: a monoid $n$ and a function that identifies
 the generators in its X-ray image:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 q :: x -> U n
 \end{Verbatim}
-We'll say that \code{m} is better than \code{n} if there is a
+We'll say that $m$ is better than $n$ if there is a
 morphism of monoids (that's a structure-preserving homomorphism):
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 h :: m -> n
 \end{Verbatim}
-whose image under \code{U} (remember, \code{U} is a functor, so it
-maps morphisms to functions) factorizes through \code{p}:
+whose image under $U$ (remember, $U$ is a functor, so it
+maps morphisms to functions) factorizes through $p$:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 q = U h . p
 \end{Verbatim}
-If you think of \code{p} as selecting the generators in \code{m};
-and \code{q} as selecting ``the same'' generators in \code{n}; then
-you can think of \code{h} as mapping these generators between the two
-monoids. Remember that \code{h}, by definition, preserves the monoidal
+If you think of $p$ as selecting the generators in $m$;
+and $q$ as selecting ``the same'' generators in $n$; then
+you can think of $h$ as mapping these generators between the two
+monoids. Remember that $h$, by definition, preserves the monoidal
 structure. It means that a product of two generators in one monoid will
 be mapped to a product of the corresponding two generators in the second
 monoid, and so on.
@@ -244,18 +245,18 @@ This ranking may be used to find the best candidate --- the free monoid.
 Here's the definition:
 
 \begin{quote}
-We'll say that \code{m} (together with the function \code{p}) is the
-\textbf{free monoid} with the generators \code{x} if and only if there
-is a \emph{unique} morphism \code{h} from \code{m} to any other
-monoid \code{n} (together with the function \code{q}) that satisfies
+We'll say that $m$ (together with the function $p$) is the
+\textbf{free monoid} with the generators $x$ if and only if there
+is a \emph{unique} morphism $h$ from $m$ to any other
+monoid $n$ (together with the function $q$) that satisfies
 the above factorization property.
 \end{quote}
 Incidentally, this answers our second question. The function
-\code{U h} is the one that has the power to collapse multiple
-elements of \code{U m} to a single element of \code{U n}. This
+$U h$ is the one that has the power to collapse multiple
+elements of $U m$ to a single element of $U n$. This
 collapse corresponds to identifying some elements of the free monoid.
-Therefore any monoid with generators \code{x} can be obtained from the
-free monoid based on \code{x} by identifying some of the elements. The
+Therefore any monoid with generators $x$ can be obtained from the
+free monoid based on $x$ by identifying some of the elements. The
 free monoid is the one where only the bare minimum of identifications
 have been made.
 
@@ -268,15 +269,15 @@ We'll come back to free monoids when we talk about adjunctions.
 \item
   You might think (as I did, originally) that the requirement that a
   homomorphism of monoids preserve the unit is redundant. After all, we
-  know that for all \code{a}
+  know that for all $a$
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 h a * h e = h (a * e) = h a
 \end{Verbatim}
-  So \code{h e} acts like a right unit (and, by analogy, as a left
-  unit). The problem is that \code{h a}, for all \code{a} might
+  So $h e$ acts like a right unit (and, by analogy, as a left
+  unit). The problem is that $h a$, for all $a$ might
   only cover a sub-monoid of the target monoid. There may be a ``true''
-  unit outside of the image of \code{h}. Show that an isomorphism
+  unit outside of the image of $h$. Show that an isomorphism
   between monoids that preserves multiplication must automatically
   preserve unit.
 \item

--- a/src/content/2.4/Representable Functors.tex
+++ b/src/content/2.4/Representable Functors.tex
@@ -49,11 +49,11 @@ Every category comes equipped with a canonical family of mappings to
 $\Set$. Those mappings are in fact functors, so they preserve the
 structure of the category. Let's build one such mapping.
 
-Let's fix one object \code{a} in \emph{C} and pick another object
-\code{x} also in \emph{C}. The hom-set \code{C(a, x)} is a set, an
-object in $\Set$. When we vary \code{x}, keeping \code{a}
-fixed, \code{C(a, x)} will also vary in $\Set$. Thus we have a
-mapping from \code{x} to $\Set$.
+Let's fix one object $a$ in $\cat{C}$ and pick another object
+$x$ also in $\cat{C}$. The hom-set $\cat{C}(a, x)$ is a set, an
+object in $\Set$. When we vary $x$, keeping $a$
+fixed, $\cat{C}(a, x)$ will also vary in $\Set$. Thus we have a
+mapping from $x$ to $\Set$.
 
 \begin{figure}[H]
 \centering
@@ -64,56 +64,56 @@ mapping from \code{x} to $\Set$.
 If we want to stress the fact that we are considering the hom-set as a
 mapping in its second argument, we use the notation:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 C(a, -)
 \end{Verbatim}
 with the dash serving as the placeholder for the argument.
 
 This mapping of objects is easily extended to the mapping of morphisms.
-Let's take a morphism \code{f} in \emph{C} between two arbitrary
-objects \code{x} and \code{y}. The object \code{x} is mapped to
-the set \code{C(a, x)}, and the object \code{y} is mapped to
-\code{C(a, y)}, under the mapping we have just defined. If this
-mapping is to be a functor, \code{f} must be mapped to a function
+Let's take a morphism $f$ in $\cat{C}$ between two arbitrary
+objects $x$ and $y$. The object $x$ is mapped to
+the set $\cat{C}(a, x)$, and the object $y$ is mapped to
+$\cat{C}(a, y)$, under the mapping we have just defined. If this
+mapping is to be a functor, $f$ must be mapped to a function
 between the two sets:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 C(a, x) -> C(a, y)
 \end{Verbatim}
 Let's define this function point-wise, that is for each argument
 separately. For the argument we should pick an arbitrary element of
-\code{C(a, x)} --- let's call it \code{h}. Morphisms are
+$\cat{C}(a, x)$ --- let's call it $h$. Morphisms are
 composable, if they match end to end. It so happens that the target of
-\code{h} matches the source of \code{f}, so their composition:
+$h$ matches the source of $f$, so their composition:
 
 \begin{Verbatim}[commandchars=\\\{\}]
-f ◦ h :: a -> y
+f \ensuremath{\circ} h :: a -> y
 \end{Verbatim}
-is a morphism going from \code{a} to \code{y}. It is therefore a
-member of \code{C(a, y)}.
+is a morphism going from $a$ to $y$. It is therefore a
+member of $\cat{C}(a, y)$.
 
 \includegraphics[width=3.12500in]{images/hom-functor.jpg}
 
-We have just found our function from \code{C(a, x)} to
-\code{C(a, y)}, which can serve as the image of \code{f}. If there
+We have just found our function from $\cat{C}(a, x)$ to
+$\cat{C}(a, y)$, which can serve as the image of $f$. If there
 is no danger of confusion, we'll write this lifted function as:
 
 \begin{Verbatim}[commandchars=\\\{\}]
 C(a, f)
 \end{Verbatim}
-and its action on a morphism \code{h} as:
+and its action on a morphism $h$ as:
 
 \begin{Verbatim}[commandchars=\\\{\}]
-C(a, f) h = f ◦ h
+C(a, f) h = f \ensuremath{\circ} h
 \end{Verbatim}
 Since this construction works in any category, it must also work in the
 category of Haskell types. In Haskell, the hom-functor is better known
 as the \code{Reader} functor:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 type Reader a x = a -> x
 \end{Verbatim}
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 instance Functor (Reader a) where
     fmap f h = f . h
 \end{Verbatim}
@@ -121,31 +121,31 @@ Now let's consider what happens if, instead of fixing the source of the
 hom-set, we fix the target. In other words, we're asking the question if
 the mapping
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 C(-, a)
 \end{Verbatim}
 is also a functor. It is, but instead of being covariant, it's
 contravariant. That's because the same kind of matching of morphisms end
-to end results in postcomposition by \code{f}; rather than
-precomposition, as was the case with \code{C(a, -)}.
+to end results in postcomposition by $f$; rather than
+precomposition, as was the case with $\cat{C}(a, -)$.
 
 We have already seen this contravariant functor in Haskell. We called it
 \code{Op}:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 type Op a x = x -> a
 \end{Verbatim}
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 instance Contravariant (Op a) where
     contramap f h = h . f
 \end{Verbatim}
 Finally, if we let both objects vary, we get a profunctor
-\code{C(-, =)}, which is contravariant in the first argument and
+$\cat{C}(-, =)$, which is contravariant in the first argument and
 covariant in the second (to underline the fact that the two arguments
 may vary independently, we use a double dash as the second placeholder).
 We have seen this profunctor before, when we talked about functoriality:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 instance Profunctor (->) where
     dimap ab cd bc = cd . bc . ab
     lmap = flip (.)
@@ -156,23 +156,23 @@ mapping of objects to hom-sets is functorial. Since contravariance is
 equivalent to a mapping from the opposite category, we can state this
 fact succintly as:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 C(-, =) :: Cop × C -> Set
 \end{Verbatim}
 
 \section{Representable Functors}\label{representable-functors}
 
-We've seen that, for every choice of an object \code{a} in \emph{C},
-we get a functor from \emph{C} to $\Set$. This kind of
+We've seen that, for every choice of an object $a$ in $\cat{C}$,
+we get a functor from $\cat{C}$ to $\Set$. This kind of
 structure-preserving mapping to $\Set$ is often called a
 \newterm{representation}. We are representing objects and morphisms of
-\emph{C} as sets and functions in $\Set$.
+$cat{C}$ as sets and functions in $\Set$.
 
-The functor \code{C(a, -)} itself is sometimes called representable.
-More generally, any functor \code{F} that is naturally isomorphic to
-the hom-functor, for some choice of \code{a}, is called
+The functor $\cat{C}(a, -)$ itself is sometimes called representable.
+More generally, any functor $F$ that is naturally isomorphic to
+the hom-functor, for some choice of $a$, is called
 \newterm{representable}. Such functor must necessarily be
-$\Set$-valued, since \code{C(a, -)} is.
+$\Set$-valued, since $\cat{C}(a, -)$ is.
 
 I said before that we often think of isomorphic sets as identical. More
 generally, we think of isomorphic \newterm{objects} in a category as
@@ -180,9 +180,9 @@ identical. That's because objects have no structure other than their
 relation to other objects (and themselves) through morphisms.
 
 For instance, we've previously talked about the category of monoids,
-\textbf{Mon}, that was initially modeled with sets. But we were careful
+$\cat{Mon}$, that was initially modeled with sets. But we were careful
 to pick as morphisms only those functions that preserved the monoidal
-structure of those sets. So if two objects in \textbf{Mon} are
+structure of those sets. So if two objects in $\cat{Mon}$ are
 isomorphic, meaning there is an invertible morphism between them, they
 have exactly the same structure. If we peeked at the sets and functions
 that they were based upon, we'd see that the unit element of one monoid
@@ -196,102 +196,102 @@ as identical, if there is an invertible natural transformation between
 them.
 
 Let's analyze the definition of the representable functor from this
-perspective. For \code{F} to be representable we require that: There
-be an object \code{a} in \emph{C}; one natural transformation α from
-\code{C(a, -)} to \code{F}; another natural transformation, β, in
+perspective. For $F$ to be representable we require that: There
+be an object $a$ in $\cat{C}$; one natural transformation α from
+$\cat{C}(a, -)$ to $F$; another natural transformation, β, in
 the opposite direction; and that their composition be the identity
 natural transformation.
 
-Let's look at the component of α at some object \code{x}. It's a
+Let's look at the component of α at some object $x$. It's a
 function in $\Set$:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 α\textsubscript{x} :: C(a, x) -> F x
 \end{Verbatim}
 The naturality condition for this transformation tells us that, for any
-morphism \code{f} from \code{x} to \code{y}, the following diagram
+morphism $f$ from $x$ to $y$, the following diagram
 commutes:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 F f ◦ α\textsubscript{x} = α\textsubscript{y} ◦ C(a, f)
 \end{Verbatim}
 In Haskell, we would replace natural transformations with polymorphic
 functions:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 alpha :: forall x. (a -> x) -> F x
 \end{Verbatim}
 with the optional \code{forall} quantifier. The naturality condition
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 fmap f . alpha = alpha . fmap f
 \end{Verbatim}
 is automatically satisfied due to parametricity (it's one of those
 theorems for free I mentioned earlier), with the understanding that
-\code{fmap} on the left is defined by the functor \code{F}, whereas
+\code{fmap} on the left is defined by the functor $F$, whereas
 the one on the right is defined by the reader functor. Since
 \code{fmap} for reader is just function precomposition, we can be even
-more explicit. Acting on \code{h}, an element of \code{C(a, x)},
+more explicit. Acting on $h$, an element of $\cat{C}(a, x)$,
 the naturality condition simplifies to:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 fmap f (alpha h) = alpha (f . h)
 \end{Verbatim}
-The other transformation, \code{beta}, goes the opposite way:
+The other transformation, $beta$, goes the opposite way:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 beta :: forall x. F x -> (a -> x)
 \end{Verbatim}
 It must respect naturality conditions, and it must be the inverse of α:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 α ◦ β = id = β ◦ α
 \end{Verbatim}
-We will see later that a natural transformation from \code{C(a, -)}
+We will see later that a natural transformation from $\cat{C}(a, -)$
 to any $\Set$-valued functor always exists (Yoneda's lemma) but it
 is not necessarily invertible.
 
 Let me give you an example in Haskell with the list functor and
-\code{Int} as \code{a}. Here's a natural transformation that does
+\code{Int} as $a$. Here's a natural transformation that does
 the job:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 alpha :: forall x. (Int -> x) -> [x] alpha h = map h [12]
 \end{Verbatim}
 I have arbitrarily picked the number 12 and created a singleton list
-with it. I can then \code{fmap} the function \code{h} over this list
-and get a list of the type returned by \code{h}. (There are actually
+with it. I can then \code{fmap} the function $h$ over this list
+and get a list of the type returned by $h$. (There are actually
 as many such transformations as there are list of integers.)
 
 The naturality condition is equivalent to the composability of
 \code{map} (the list version of \code{fmap}):
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 map f (map h [12]) = map (f . h) [12]
 \end{Verbatim}
 But if we tried to find the inverse transformation, we would have to go
-from a list of arbitrary type \code{x} to a function returning
-\code{x}:
+from a list of arbitrary type $x$ to a function returning
+$x$:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 beta :: forall x. [x] -> (Int -> x)
 \end{Verbatim}
-You might think of retrieving an \code{x} from the list, e.g., using
+You might think of retrieving an $x$ from the list, e.g., using
 \code{head}, but that won't work for an empty list. Notice that there
-is no choice for the type \code{a} (in place of \code{Int}) that
+is no choice for the type $a$ (in place of \code{Int}) that
 would work here. So the list functor is not representable.
 
 Remember when we talked about Haskell (endo-) functors being a little
 like containers? In the same vein we can think of representable functors
 as containers for storing memoized results of function calls (the
 members of hom-sets in Haskell are just functions). The representing
-object, the type \code{a} in \code{C(a, -)}, is thought of as the
+object, the type $a$ in $\cat{C}(a, -)$, is thought of as the
 key type, with which we can access the tabulated values of a function.
 The transformation we called α is called \code{tabulate}, and its
 inverse, β, is called \code{index}. Here's a (slightly simplified)
 \code{Representable} class definition:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 class Representable f where
     type Rep f :: *
     tabulate :: (Rep f -> x) -> f x
@@ -304,7 +304,7 @@ type (as opposed to a type constructor, or other more exotic kinds).
 
 Infinite lists, or streams, which cannot be empty, are representable.
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 data Stream x = Cons x (Stream x)
 \end{Verbatim}
 You can think of them as memoized values of a function taking an
@@ -316,7 +316,7 @@ values. Of course, this is only possible because Haskell is lazy. The
 values are evaluated on demand. You access the memoized values using
 \code{index}:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 instance Representable Stream where
     type Rep Stream = Integer
     tabulate f = Cons (f 0) (tabulate (f . (+1)))
@@ -326,22 +326,22 @@ It's interesting that you can implement a single memoization scheme to
 cover a whole family of functions with arbitrary return types.
 
 Representability for contravariant functors is similarly defined, except
-that we keep the second argument of \code{C(-, a)} fixed. Or,
-equivalently, we may consider functors from \emph{C}\textsuperscript{op}
-to $\Set$, because \code{C\textsuperscript{op}(a, -)} is the same as
-\code{C(-, a)}.
+that we keep the second argument of $\cat{C}(-, a)$ fixed. Or,
+equivalently, we may consider functors from $\cat{C}^{op}$
+to $\Set$, because $\cat{C}^{op}(a, -)$ is the same as
+$\cat{C}(-, a)$.
 
 There is an interesting twist to representability. Remember that
 hom-sets can internally be treated as exponential objects, in cartesian
-closed categories. The hom-set \code{C(a, x)} is equivalent to
-\code{xa}, and for a representable functor \code{F} we can write:
+closed categories. The hom-set $\cat{C}(a, x)$ is equivalent to
+$xa$, and for a representable functor $F$ we can write:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 -a = F
 \end{Verbatim}
 Let's take the logarithm of both sides, just for kicks:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 a = log F
 \end{Verbatim}
 Of course, this is a purely formal transformation, but if you know some
@@ -384,7 +384,7 @@ explore alternative implementations that have practical value.
 \item
   The functor:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 Pair a = Pair a a
 \end{Verbatim}
   is representable. Can you guess the type that represents it? Implement

--- a/src/content/2.5/The Yoneda Lemma.tex
+++ b/src/content/2.5/The Yoneda Lemma.tex
@@ -13,7 +13,7 @@ theorem in group theory (every group is isomorphic to a permutation
 group of some set).
 
 The setting for the Yoneda lemma is an arbitrary category \emph{C}
-together with a functor \code{F} from \emph{C} to $\Set$. We've
+together with a functor $F$ from $\cat{C}$ to $\Set$. We've
 seen in the previous section that some $\Set$-valued functors are
 representable, that is isomorphic to a hom-functor. The Yoneda lemma
 tells us that all $\Set$-valued functors can be obtained from
@@ -30,26 +30,26 @@ have for transporting the components of natural transformations.
 $\Set$ happens to be a very arrow-rich category.
 
 The Yoneda lemma tells us that a natural transformation between a
-hom-functor and any other functor \code{F} is completely determined by
+hom-functor and any other functor $F$ is completely determined by
 specifying the value of its single component at just one point! The rest
 of the natural transformation just follows from naturality conditions.
 
 So let's review the naturality condition between the two functors
 involved in the Yoneda lemma. The first functor is the hom-functor. It
-maps any object \code{x} in \emph{C} to the set of morphisms
-\code{C(a, x)} --- for \code{a} a fixed object in \emph{C}. We've
-also seen that it maps any morphism \code{f} from \code{x} to
-\code{y} to \code{C(a, f)}.
+maps any object $x$ in $\cat{C}$ to the set of morphisms
+$\cat{C}(a, x)$ --- for $a$ a fixed object in $\cat{C}$. We've
+also seen that it maps any morphism $f$ from $x$ to
+$y$ to $\cat{C}(a, f)$.
 
 The second functor is an arbitrary $\Set$-valued functor
-\code{F}.
+$F$.
 
 Let's call the natural transformation between these two functors
-\code{α}. Because we are operating in $\Set$, the components of
-the natural transformation, like \code{αx} or \code{αy}, are just
+$\alpha$. Because we are operating in $\Set$, the components of
+the natural transformation, like $αx$ or $αy$, are just
 regular functions between sets:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 α\textsubscript{x} :: C(a, x) -> F x
 α\textsubscript{y} :: C(a, y) -> F y
 \end{Verbatim}
@@ -61,34 +61,34 @@ regular functions between sets:
 
 \noindent
 And because these are just functions, we can look at their values at
-specific points. But what's a point in the set \code{C(a, x)}? Here's
-the key observation: Every point in the set \code{C(a, x)} is also a
-morphism \code{h} from \code{a} to \code{x}.
+specific points. But what's a point in the set $\cat{C}(a, x)$? Here's
+the key observation: Every point in the set $\cat{C}(a, x)$ is also a
+morphism $h$ from $a$ to $x$.
 
-So the naturality square for \code{α}:
+So the naturality square for $α$:
 
 \begin{Verbatim}[commandchars=\\\{\}]
-α\textsubscript{y} ◦ C(a, f) = F f ◦ α\textsubscript{x}
+α\textsubscript{y} \ensuremath{\circ} C(a, f) = F f \ensuremath{\circ} α\textsubscript{x}
 \end{Verbatim}
-becomes, point-wise, when acting on \code{h}:
+becomes, point-wise, when acting on $h$:
 
 \begin{Verbatim}[commandchars=\\\{\}]
 α\textsubscript{y} (C(a, f) h) = (F f) (α\textsubscript{x} h)
 \end{Verbatim}
 You might recall from the previous section that the action of the
-hom-functor \code{C(a,-)} on a morphism \code{f} was defined as
+hom-functor $\cat{C}(a,-)$ on a morphism $f$ was defined as
 precomposition:
 
 \begin{Verbatim}[commandchars=\\\{\}]
-C(a, f) h = f ◦ h
+C(a, f) h = f \ensuremath{\circ} h
 \end{Verbatim}
 which leads to:
 
 \begin{Verbatim}[commandchars=\\\{\}]
-αy (f ◦ h) = (F f) (αx h)
+αy (f \ensuremath{\circ} h) = (F f) (αx h)
 \end{Verbatim}
 Just how strong this condition is can be seen by specializing it to the
-case of \code{x} equal to \code{a}.
+case of $x$ equal to $a$.
 
 \begin{figure}[H]
 \centering
@@ -96,29 +96,29 @@ case of \code{x} equal to \code{a}.
 \end{figure}
 
 \noindent
-In that case \code{h} becomes a morphism from \code{a} to
-\code{a}. We know that there is at least one such morphism,
-\code{h = id\textsubscript{a}}. Let's plug it in:
+In that case $h$ becomes a morphism from $a$ to
+$a$. We know that there is at least one such morphism,
+$h = id_{a}$. Let's plug it in:
 
 \begin{Verbatim}[commandchars=\\\{\}]
 α\textsubscript{y} f = (F f) (α\textsubscript{a} id\textsubscript{a})
 \end{Verbatim}
 Notice what has just happened: The left hand side is the action of
-\code{α\textsubscript{y}} on an arbitrary element \code{f} of \code{C(a, y)}. And
-it is totally determined by the single value of \code{α\textsubscript{a}} at
-\code{id\textsubscript{a}}. We can pick any such value and it will generate a natural
-transformation. Since the values of \code{α\textsubscript{a}} are in the set
-\code{F a}, any point in \code{F a} will define some \code{α}.
+$α_y$ on an arbitrary element $f$ of $\cat{C}(a, y)$. And
+it is totally determined by the single value of $α_a$ at
+$id_a$. We can pick any such value and it will generate a natural
+transformation. Since the values of $α_a$ are in the set
+$F a$, any point in $F a$ will define some $α$.
 
-Conversely, given any natural transformation \code{α} from
-\code{C(a, -)} to \code{F}, you can evaluate it at \code{id\textsubscript{a}} to
-get a point in \code{F a}.
+Conversely, given any natural transformation $α$ from
+$\cat{C}(a, -)$ to $F$, you can evaluate it at $id_a$ to
+get a point in $F a$.
 
 We have just proven the Yoneda lemma:
 
 \begin{quote}
 There is a one-to-one correspondence between natural transformations
-from \code{C(a, -)} to \code{F} and elements of \code{F a}. 
+from $\cat{C}(a, -)$ to $F$ and elements of $F a$. 
 \end{quote}
 in other words,
 
@@ -126,8 +126,8 @@ in other words,
 \begin{Verbatim}[commandchars=\\\{\}]
 Nat(C(a, -), F) \ensuremath{\cong} F a
 \end{Verbatim}
-Or, if we use the notation \code{{[}C, Set{]}} for the functor
-category between \emph{C} and $\Set$, the set of natural
+Or, if we use the notation $[C, Set]$ for the functor
+category between $\cat{C}$ and $\Set$, the set of natural
 transformation is just a hom-set in that category, and we can write:
 
 \begin{Verbatim}[commandchars=\\\{\}]
@@ -138,21 +138,21 @@ isomorphism.
 
 Now let's try to get some intuition about this result. The most amazing
 thing is that the whole natural transformation crystallizes from just
-one nucleation site: the value we assign to it at \code{id\textsubscript{a}}. It
+one nucleation site: the value we assign to it at $id_a$. It
 spreads from that point following the naturality condition. It floods
-the image of \emph{C} in $\Set$. So let's first consider what the
-image of \emph{C} is under \code{C(a, -)}.
+the image of $\cat{C}$ in $\Set$. So let's first consider what the
+image of $\cat{C}$ is under $\cat{C}(a, -)$.
 
-Let's start with the image of \code{a} itself. Under the hom-functor
-\code{C(a, -)}, \code{a} is mapped to the set \code{C(a, a)}.
-Under the functor \code{F}, on the other hand, it is mapped to the set
-\code{F a}. The component of the natural transformation \code{α\textsubscript{a}}
-is some function from \code{C(a, a)} to \code{F a}. Let's focus on
-just one point in the set \code{C(a, a)}, the point corresponding to
-the morphism \code{id\textsubscript{a}}. To emphasize the fact that it's just a point
-in a set, let's call it \code{p}. The component \code{α\textsubscript{a}} should map
-\code{p} to some point \code{q} in \code{F a}. I'll show you that
-any choice of \code{q} leads to a unique natural transformation.
+Let's start with the image of $a$ itself. Under the hom-functor
+$\cat{C}(a, -)$, $a$ is mapped to the set $\cat{C}(a, a)$.
+Under the functor $F$, on the other hand, it is mapped to the set
+$F a$. The component of the natural transformation $α_a$
+is some function from $\cat{C}(a, a)$ to $F a$. Let's focus on
+just one point in the set $\cat{C}(a, a)$, the point corresponding to
+the morphism $id_a$. To emphasize the fact that it's just a point
+in a set, let's call it $p$. The component $α_a$ should map
+$p$ to some point $q$ in $F a$. I'll show you that
+any choice of $q$ leads to a unique natural transformation.
 
 \begin{figure}[H]
 \centering
@@ -160,15 +160,15 @@ any choice of \code{q} leads to a unique natural transformation.
 \end{figure}
 
 \noindent
-The first claim is that the choice of one point \code{q} uniquely
-determines the rest of the function \code{α\textsubscript{a}}. Indeed, let's pick any
-other point, \code{p'} in \code{C(a, a)}, corresponding to
-some morphism \code{g} from \code{a} to \code{a}. And here's where
-the magic of the Yoneda lemma happens: \code{g} can be viewed as a
-point \code{p'} in the set \code{C(a, a)}. At the same time,
+The first claim is that the choice of one point $q$ uniquely
+determines the rest of the function $α_a$. Indeed, let's pick any
+other point, $p'$ in $\cat{C}(a, a)$, corresponding to
+some morphism $g$ from $a$ to $a$. And here's where
+the magic of the Yoneda lemma happens: $g$ can be viewed as a
+point $p'$ in the set $\cat{C}(a, a)$. At the same time,
 it selects two \newterm{functions} between sets. Indeed, under the
-hom-functor, the morphism \code{g} is mapped to a function
-\code{C(a, g)}; and under \code{F} it's mapped to \code{F g}.
+hom-functor, the morphism $g$ is mapped to a function
+$\cat{C}(a, g)$; and under $F$ it's mapped to $F g$.
 
 \begin{figure}[H]
 \centering
@@ -176,44 +176,44 @@ hom-functor, the morphism \code{g} is mapped to a function
 \end{figure}
 
 \noindent
-Now let's consider the action of \code{C(a, g)} on our original
-\code{p} which, as you remember, corresponds to \code{id\textsubscript{a}}. It is
-defined as precomposition, \code{g◦id\textsubscript{a}}, which is equal to \code{g},
-which corresponds to our point \code{p'}. So the morphism
-\code{g} is mapped to a function that, when acting on \code{p}
-produces \code{p'}, which is \code{g}. We have come full
+Now let's consider the action of $\cat{C}(a, g)$ on our original
+$p$ which, as you remember, corresponds to $id_a$. It is
+defined as precomposition, $g \circ id_a$, which is equal to $g$,
+which corresponds to our point $p'$. So the morphism
+$g$ is mapped to a function that, when acting on $p$
+produces $p'$, which is $g$. We have come full
 circle!
 
-Now consider the action of \code{F g} on \code{q}. It is some
-\code{q'}, a point in \code{F a}. To complete the naturality
-square, \code{p'} must be mapped to \code{q'} under
-\code{α\textsubscript{a}}. We picked an arbitrary \code{p'} (an arbitrary
-\code{g}) and derived its mapping under \code{α\textsubscript{a}}. The function
-\code{α\textsubscript{a}} is thus completely determined.
+Now consider the action of $F g$ on $q$. It is some
+$q'$, a point in $F a$. To complete the naturality
+square, $p'$ must be mapped to $q'$ under
+$α_a$. We picked an arbitrary $p'$ (an arbitrary
+$g$) and derived its mapping under $α_a$. The function
+$α_a$ is thus completely determined.
 
-The second claim is that \code{α\textsubscript{x}} is uniquely determined for any
-object \code{x} in \emph{C} that is connected to \code{a}. The
+The second claim is that $α_x$ is uniquely determined for any
+object $x$ in $\cat{C}$ that is connected to $a$. The
 reasoning is analogous, except that now we have two more sets,
-\code{C(a, x)} and \code{F x}, and the morphism \code{g} from
-\code{a} to \code{x} is mapped, under the hom-functor, to:
+$\cat{C}(a, x)$ and $F x$, and the morphism $g$ from
+$a$ to $x$ is mapped, under the hom-functor, to:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 C(a, g) :: C(a, a) -> C(a, x)
 \end{Verbatim}
-and under \code{F} to:
+and under $F$ to:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 F g :: F a -> F x
 \end{Verbatim}
-Again, \code{C(a, g)} acting on our \code{p} is given by the
-precomposition: \code{g ◦ id\textsubscript{a}}, which corresponds to a point
-\code{p'} in \code{C(a, x)}. Naturality determines the value
-of \code{αx} acting on \code{p'} to be:
+Again, $\cat{C}(a, g)$ acting on our $p$ is given by the
+precomposition: $g \circ id_a$, which corresponds to a point
+$p'$ in $\cat{C}(a, x)$. Naturality determines the value
+of $αx$ acting on $p'$ to be:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 q' = (F g) q
 \end{Verbatim}
-Since \code{p'} was arbitrary, the whole function \code{α\textsubscript{x}} is
+Since $p'$ was arbitrary, the whole function $α_x$ is
 thus determined.
 
 \begin{figure}[H]
@@ -222,8 +222,8 @@ thus determined.
 \end{figure}
 
 \noindent
-What if there are objects in \emph{C} that have no connection to
-\code{a}? They are all mapped under \code{C(a, -)} to a single set
+What if there are objects in $\cat{C}$ that have no connection to
+$a$? They are all mapped under $\cat{C}(a, -)$ to a single set
 --- the empty set. Recall that the empty set is the initial object in
 the category of sets. It means that there is a unique function from this
 set to any other set. We called this function \code{absurd}. So here,
@@ -238,22 +238,22 @@ only functions that are not lossy are the ones that are invertible ---
 the isomorphisms. It follows then that the best structure-preserving
 $\Set$-valued functors are the representable ones. They are either
 the hom-functors or the functors that are naturally isomorphic to
-hom-functors. Any other functor \code{F} is obtained from a
+hom-functors. Any other functor $F$ is obtained from a
 hom-functor through a lossy transformation. Such a transformation may
 not only lose information, but it may also cover only a small part of
-the image of the functor \code{F} in $\Set$.
+the image of the functor $F$ in $\Set$.
 
 \section{Yoneda in Haskell}\label{yoneda-in-haskell}
 
 We have already encountered the hom-functor in Haskell under the guise
 of the reader functor:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 type Reader a x = a -> x
 \end{Verbatim}
 The reader maps morphisms (here, functions) by precomposition:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 instance Functor (Reader a) where
     fmap f h = f . h
 \end{Verbatim}
@@ -261,23 +261,23 @@ The Yoneda lemma tells us that the reader functor can be naturally
 mapped to any other functor.
 
 A natural transformation is a polymorphic function. So given a functor
-\code{F}, we have a mapping to it from the reader functor:
+$F$, we have a mapping to it from the reader functor:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 alpha :: forall x . (a -> x) -> F x
 \end{Verbatim}
 As usual, \code{forall} is optional, but I like to write it explicitly
 to emphasize parametric polymorphism of natural transformations.
 
 The Yoneda lemma tells us that these natural transformations are in
-one-to-one correspondence with the elements of \code{F a}:
+one-to-one correspondence with the elements of $F a$:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 forall x . (a -> x) -> F x \ensuremath{\cong} F a
 \end{Verbatim}
 The right hand side of this identity is what we would normally consider
 a data structure. Remember the interpretation of functors as generalized
-containers? \code{F a} is a container of \code{a}. But the left
+containers? $F a$ is a container of $a$. But the left
 hand side is a polymorphic function that takes a function as an
 argument. The Yoneda lemma tells us that the two representations are
 equivalent --- they contain the same information.
@@ -285,24 +285,24 @@ equivalent --- they contain the same information.
 Another way of saying this is: Give me a polymorphic function of the
 type:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 alpha :: forall x . (a -> x) -> F x
 \end{Verbatim}
-and I'll produce a container of \code{a}. The trick is the one we used
+and I'll produce a container of $a$. The trick is the one we used
 in the proof of the Yoneda lemma: we call this function with \code{id}
-to get an element of \code{F a}:
+to get an element of $F a$:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 alpha id :: F a
 \end{Verbatim}
-The converse is also true: Given a value of the type \code{F a}:
+The converse is also true: Given a value of the type $F a$:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 fa :: F a
 \end{Verbatim}
 one can define a polymorphic function:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 alpha h = fmap h fa
 \end{Verbatim}
 of the correct type. You can easily go back and forth between the two
@@ -315,15 +315,15 @@ some applications than the other.
 The simplest illustration of this principle is the code transformation
 that is often used in compiler construction: the continuation passing
 style or \acronym{CPS}. It's the simplest application of the Yoneda lemma to the
-identity functor. Replacing \code{F} with identity produces:
+identity functor. Replacing $F$ with identity produces:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 forall r . (a -> r) -> r \ensuremath{\cong} a
 \end{Verbatim}
-The interpretation of this formula is that any type \code{a} can be
-replaced by a function that takes a ``handler'' for \code{a}. A
-handler is a function accepting \code{a} and performing the rest of
-the computation --- the continuation. (The type \code{r} usually
+The interpretation of this formula is that any type $a$ can be
+replaced by a function that takes a ``handler'' for $a$. A
+handler is a function accepting $a$ and performing the rest of
+the computation --- the continuation. (The type $r$ usually
 encapsulates some kind of status code.)
 
 This style of programming is very common in UIs, in asynchronous
@@ -344,11 +344,11 @@ functors.
 
 Equivalently, we can derive the co-Yoneda lemma by fixing the target
 object of our hom-functors instead of the source. We get the
-contravariant hom-functor from \emph{C} to $\Set$:
-\code{C(-, a)}. The contravariant version of the Yoneda lemma
+contravariant hom-functor from $\cat{C}$ to $\Set$:
+$\cat{C}(-, a)$. The contravariant version of the Yoneda lemma
 establishes one-to-one correspondence between natural transformations
-from this functor to any other contravariant functor \code{F} and the
-elements of the set \code{F a}:
+from this functor to any other contravariant functor $F$ and the
+elements of the set $F a$:
 
 \begin{Verbatim}[commandchars=\\\{\}]
 Nat(C(-, a), F) \ensuremath{\cong} F a
@@ -366,14 +366,14 @@ called the Yoneda lemma.
 \begin{enumerate}
 \tightlist
 \item
-  Show that the two functions \code{phi} and \code{psi} that form
+  Show that the two functions $\phi$ and $\psi$ that form
   the Yoneda isomorphism in Haskell are inverses of each other.
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 phi :: (forall x . (a -> x) -> F x) -> F a
 phi alpha = alpha id
 \end{Verbatim}
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 psi :: F a -> (forall x . (a -> x) -> F x)
 psi fa h = fmap h fa
 \end{Verbatim}

--- a/src/content/2.6/Yoneda Embedding.tex
+++ b/src/content/2.6/Yoneda Embedding.tex
@@ -1,26 +1,26 @@
-\lettrine[lhang=0.17]{W}{e've seen previously} that, when we fix an object \code{a} in the
-category \emph{C}, the mapping \code{C(a, -)} is a (covariant)
-functor from \emph{C} to $\Set$.
+\lettrine[lhang=0.17]{W}{e've seen previously} that, when we fix an object $a$ in the
+category $\cat{C}$, the mapping $\cat{C}(a, -)$ is a (covariant)
+functor from $\cat{C}$ to $\Set$.
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 x -> C(a, x)
 \end{Verbatim}
-(The codomain is $\Set$ because the hom-set C(a, x) is a
+(The codomain is $\Set$ because the hom-set $\cat{C}(a, x)$ is a
 \emph{set}.) We call this mapping a hom-functor --- we have previously
 defined its action on morphisms as well.
 
-Now let's vary \code{a} in this mapping. We get a new mapping that
-assigns the hom-\emph{functor} \code{C(a, -)} to any \code{a}.
+Now let's vary $a$ in this mapping. We get a new mapping that
+assigns the hom-\emph{functor} $\cat{C}(a, -)$ to any $a$.
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 a -> C(a, -)
 \end{Verbatim}
-It's a mapping of objects from category \emph{C} to functors, which are
+It's a mapping of objects from category $\cat{C}$ to functors, which are
 \emph{objects} in the functor category (see the section about functor
 categories in
 \hyperref[natural-transformations]{Natural
-Transformations}). Let's use the notation \code{{[}C, Set{]}} for the
-functor category from \emph{C} to $\Set$. You may also recall that
+Transformations}). Let's use the notation $[\cat{C}, \Set]$ for the
+functor category from $\cat{C}$ to $\Set$. You may also recall that
 hom-functors are the prototypical
 \hyperref[chap-representable-functors]{representable
 functors}.
@@ -29,14 +29,14 @@ Every time we have a mapping of objects between two categories, it's
 natural to ask if such a mapping is also a functor. In other words
 whether we can lift a morphism from one category to a morphism in the
 other category. A morphism in \emph{C} is just an element of
-\code{C(a, b)}, but a morphism in the functor category
-\code{{[}C, Set{]}} is a natural transformation. So we are looking
+$\cat{C}(a, b)$, but a morphism in the functor category
+$[\cat{C}, \Set]$ is a natural transformation. So we are looking
 for a mapping of morphisms to natural transformations.
 
 Let's see if we can find a natural transformation corresponding to a
 morphism \code{f :: a->b}. First, lets see what
-\code{a} and \code{b} are mapped to. They are mapped to two
-functors: \code{C(a, -)} and \code{C(b, -)}. We need a natural
+$a$ and $b$ are mapped to. They are mapped to two
+functors: $\cat{C}(a, -)$ and $\cat{C}(b, -)$. We need a natural
 transformation between those two functors.
 
 And here's the trick: we use the Yoneda lemma:
@@ -44,8 +44,8 @@ And here's the trick: we use the Yoneda lemma:
 \begin{Verbatim}[commandchars=\\\{\}]
 [C, Set](C(a, -), F) \ensuremath{\cong} F a
 \end{Verbatim}
-and replace the generic \code{F} with the hom-functor
-\code{C(b, -)}. We get:
+and replace the generic $F$ with the hom-functor
+$\cat{C}(b, -)$. We get:
 
 \begin{Verbatim}[commandchars=\\\{\}]
 [C, Set](C(a, -), C(b, -)) \ensuremath{\cong} C(b, a)
@@ -60,7 +60,7 @@ and replace the generic \code{F} with the hom-functor
 This is exactly the natural transformation between the two hom-functors
 we were looking for, but with a little twist: We have a mapping between
 a natural transformation and a morphism --- an element of
-\code{C(b, a)} --- that goes in the ``wrong'' direction. But that's
+$\cat{C}(b, a)$ --- that goes in the ``wrong'' direction. But that's
 okay; it only means that the functor we are looking at is contravariant.
 
 \begin{figure}[H]
@@ -70,7 +70,7 @@ okay; it only means that the functor we are looking at is contravariant.
 
 \noindent
 Actually, we've got even more than we bargained for. The mapping from
-\emph{C} to \code{{[}C, Set{]}} is not only a contravariant functor
+\emph{C} to $[\cat{C}, \Set]$ is not only a contravariant functor
 --- it is a \emph{fully faithful} functor. Fullness and faithfulness are
 properties of functors that describe how they map hom-sets.
 
@@ -82,45 +82,45 @@ A \emph{full} functor is \newterm{surjective} on hom-sets, meaning that it
 maps one hom-set \emph{onto} the other hom-set, fully covering the
 latter.
 
-A fully faithful functor \code{F} is a \newterm{bijection} on hom-sets
+A fully faithful functor $F$ is a \newterm{bijection} on hom-sets
 --- a one to one matching of all elements of both sets. For every pair
-of objects \code{a} and \code{b} in the source category \emph{C}
-there is a bijection between \code{C(a, b)} and
-\code{D(F a, F b)}, where \emph{D} is the target category of
-\code{F} (in our case, the functor category, \code{{[}C, Set{]}}).
-Notice that this doesn't mean that \code{F} is a bijection on
-\emph{objects}. There may be objects in \emph{D} that are not in the
-image of \code{F}, and we can't say anything about hom-sets for those
+of objects $a$ and $b$ in the source category $\cat{C}$
+there is a bijection between $\cat{C}(a, b)$ and
+$\cat{D}(F a, F b)$, where $\cat{D}$ is the target category of
+$F$ (in our case, the functor category, $[\cat{C}, \Set]$).
+Notice that this doesn't mean that $F$ is a bijection on
+\emph{objects}. There may be objects in $\cat{D}$ that are not in the
+image of $F$, and we can't say anything about hom-sets for those
 objects.
 
 \section{The Embedding}\label{the-embedding}
 
 The (contravariant) functor we have just described, the functor that
-maps objects in \emph{C} to functors in \code{{[}C, Set{]}}:
+maps objects in \emph{C} to functors in $[\cat{C}, \Set]$:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 a -> C(a, -)
 \end{Verbatim}
 defines the \newterm{Yoneda embedding}. It \emph{embeds} a category
-\emph{C} (strictly speaking, the category \emph{C\textsuperscript{op}},
+$\cat{C}$ (strictly speaking, the category $\cat{C}^{op}$,
 because of contravariance) inside the functor category
-\code{{[}C, Set{]}}. It not only maps objects in \emph{C} to
+$[\cat{C}, \Set]$. It not only maps objects in $\cat{C}$ to
 functors, but also faithfully preserves all connections between them.
 
 This is a very useful result because mathematicians know a lot about the
 category of functors, especially functors whose codomain is
 $\Set$. We can get a lot of insight about an arbitrary category
-\emph{C} by embedding it in the functor category.
+$\cat{C}$ by embedding it in the functor category.
 
 Of course there is a dual version of the Yoneda embedding, sometimes
 called the co-Yoneda embedding. Observe that we could have started by
 fixing the target object (rather than the source object) of each
-hom-set, \code{C(-, a)}. That would give us a contravariant
-hom-functor. Contravariant functors from \emph{C} to $\Set$ are
+hom-set, $\cat{C}(-, a)$. That would give us a contravariant
+hom-functor. Contravariant functors from $\cat{C}$ to $\Set$ are
 our familiar presheaves (see, for instance,
 \hyperref[limits-and-colimits]{Limits
 and Colimits}). The co-Yoneda embedding defines the embedding of a
-category \emph{C} in the category of presheaves. Its action on morphisms
+category $\cat{C}$ in the category of presheaves. Its action on morphisms
 is given by:
 
 \begin{Verbatim}[commandchars=\\\{\}]
@@ -142,35 +142,35 @@ forall x. (a -> x) -> (b -> x) \ensuremath{\cong} b -> a
 \code{((->) a)}.)
 
 The left hand side of this identity is a polymorphic function that,
-given a function from \code{a} to \code{x} and a value of type
-\code{b}, can produce a value of type \code{x} (I'm uncurrying ---
+given a function from $a$ to $x$ and a value of type
+$b$, can produce a value of type $x$ (I'm uncurrying ---
 dropping the parentheses around --- the function
-\code{b -> x}). The only way this can be done for all
-\code{x} is if our function knows how to convert a \code{b} to an
-\code{a}. It has to secretly have access to a function
-\code{b->a}.
+$b \rightarrow x$). The only way this can be done for all
+$x$ is if our function knows how to convert a $b$ to an
+$a$. It has to secretly have access to a function
+$b \rightarrow a$.
 
 Given such a converter, \code{btoa}, one can define the left hand
 side, call it\code{fromY}, as:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 fromY :: (a -> x) -> b -> x
 fromY f b = f (btoa b)
 \end{Verbatim}
 Conversely, given a function \code{fromY} we can recover the converter
 by calling \code{fromY} with the identity:
 
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}
 fromY id :: b -> a
 \end{Verbatim}
 This establishes the bijection between functions of the type
 \code{fromY} and \code{btoa}.
 
 An alternative way of looking at this isomorphism is that it's a CPS
-encoding of a function from \code{b} to \code{a}. The argument
-\code{a->x} is a continuation (the handler). The result
-is a function from \code{b} to \code{x} which, when called with a
-value of type \code{b}, will execute the continuation precomposed with
+encoding of a function from $b$ to $a$. The argument
+$a \rightarrow x$ is a continuation (the handler). The result
+is a function from $b$ to $x$ which, when called with a
+value of type $b$, will execute the continuation precomposed with
 the function being encoded.
 
 The Yoneda embedding also explains some of the alternative
@@ -183,24 +183,24 @@ of lenses\urlfootnote{https://bartoszmilewski.com/2015/07/13/from-lenses-to-yone
 This example was suggested by Robert Harper. It's the application of the
 Yoneda embedding to a category defined by a preorder. A preorder is a
 set with an ordering relation between its elements that's traditionally
-written as \code{<=} (less than or equal). The ``pre'' in
+written as $\Leftarrow$ (less than or equal). The ``pre'' in
 preorder is there because we're only requiring the relation to be
 transitive and reflexive but not necessarily antisymmetric (so it's
 possible to have cycles).
 
 A set with the preorder relation gives rise to a category. The objects
-are the elements of this set. A morphism from object \code{a} to
-\code{b} either doesn't exist, if the objects cannot be compared or if
-it's not true that \code{a <= b}; or it exists if
-\code{a <= b}, and it points from \code{a} to
-\code{b}. There is never more than one morphism from one object to
+are the elements of this set. A morphism from object $a$ to
+$b$ either doesn't exist, if the objects cannot be compared or if
+it's not true that $a \Leftarrow b$; or it exists if
+$a \Leftarrow b$, and it points from $a$ to
+$b$. There is never more than one morphism from one object to
 another. Therefore any hom-set in such a category is either an empty set
-or a one-element set. Such a category is called \newterm{thin}.
+or a one-element set. Such a category is called $\cat{thin}$.
 
 It's easy to convince yourself that this construction is indeed a
 category: The arrows are composable because, if
-\code{a <= b} and \code{b <= c} then
-\code{a <= c}; and the composition is associative. We also
+$a \Leftarrow b$ and $b \Leftarrow c$ then
+$a \Leftarrow c$; and the composition is associative. We also
 have the identity arrows because every element is (less than or) equal
 to itself (reflexivity of the underlying relation).
 
@@ -211,14 +211,14 @@ particular, we're interested in its action on morphisms:
 [C, Set](C(-, a), C(-, b)) \ensuremath{\cong} C(a, b)
 \end{Verbatim}
 The hom-set on the right hand side is non-empty if and only if
-\code{a <= b} --- in which case it's a one-element set.
-Consequently, if \code{a <= b}, there exists a single
+$a \Leftarrow b$ --- in which case it's a one-element set.
+Consequently, if $a \Leftarrow b$, there exists a single
 natural transformation on the left. Otherwise there is no natural
 transformation.
 
 So what's a natural transformation between hom-functors in a preorder?
-It should be a family of functions between sets \code{C(-, a)} and
-\code{C(-, b)}. In a preorder, each of these sets can either be empty
+It should be a family of functions between sets $\cat{C}(-, a)$ and
+$\cat{C}(-, b)$. In a preorder, each of these sets can either be empty
 or a singleton. Let's see what kind of functions are there at our
 disposal.
 
@@ -232,78 +232,78 @@ empty set (what would the value of such a function be when acting on the
 single element?).
 
 So our natural transformation will never connect a singleton hom-set to
-an empty hom-set. In other words, if \code{x <= a}
-(singleton hom-set \code{C(x, a)}) then \code{C(x, b)} cannot be
-empty. A non-empty \code{C(x, b)} means that \code{x} is less or
-equal to \code{b}. So the existence of the natural transformation in
-question requires that, for every \code{x}, if
-\code{x <= a} then \code{x <= b}.
+an empty hom-set. In other words, if $x \Leftarrow a$
+(singleton hom-set $\cat{C}(x, a)$) then $\cat{C}(x, b)$ cannot be
+empty. A non-empty $\cat{C}(x, b)$ means that $x$ is less or
+equal to $b$. So the existence of the natural transformation in
+question requires that, for every $x$, if
+$x \Leftarrow a$ then $x \Leftarrow b$.
 
 \begin{Verbatim}[commandchars=\\\{\}]
 for all x, x ≤ a \ensuremath{\Rightarrow} x ≤ b
 \end{Verbatim}
 On the other hand, co-Yoneda tells us that the existence of this natural
-transformation is equivalent to \code{C(a, b)} being non-empty, or to
-\code{a <= b}. Together, we get:
+transformation is equivalent to $\cat{C}(a, b)$ being non-empty, or to
+$a \Leftarrow b$. Together, we get:
 
 \begin{Verbatim}[commandchars=\\\{\}]
 a ≤ b if and only if for all x, x ≤ a \ensuremath{\Rightarrow} x ≤ b
 \end{Verbatim}
 We could have arrived at this result directly. The intuition is that, if
-\code{a <= b} then all elements that are below \code{a}
-must also be below \code{b}. Conversely, when you substitute
-\code{a} for \code{x} on the right hand side, it follows that
-\code{a <= b}. But you must admit that arriving at this
+$a \Leftarrow b$ then all elements that are below $a$
+must also be below $b$. Conversely, when you substitute
+$a$ for $x$ on the right hand side, it follows that
+$a \Leftarrow b$. But you must admit that arriving at this
 result through the Yoneda embedding is much more exciting.
 
 \section{Naturality}\label{naturality}
 
 The Yoneda lemma establishes the isomorphism between the set of natural
 transformations and an object in $\Set$. Natural transformations
-are morphisms in the functor category \code{{[}C, Set{]}}. The set of
+are morphisms in the functor category $[\cat{C}, \Set]$. The set of
 natural transformation between any two functors is a hom-set in that
 category. The Yoneda lemma is the isomorphism:
 
 \begin{Verbatim}[commandchars=\\\{\}]
 [C, Set](C(a, -), F) \ensuremath{\cong} F a
 \end{Verbatim}
-This isomorphism turns out to be natural in both \code{F} and
-\code{a}. In other words, it's natural in \code{(F, a)}, a pair
-taken from the product category \code{{[}C, Set{]} × C}. Notice
-that we are now treating \code{F} as an \newterm{object} in the functor
+This isomorphism turns out to be natural in both $F$ and
+$a$. In other words, it's natural in $(F, a)$, a pair
+taken from the product category  $[\cat{C}, \Set] \times C$. Notice
+that we are now treating $F$ as an \newterm{object} in the functor
 category.
 
 Let's think for a moment what this means. A natural isomorphism is an
 invertible \newterm{natural transformation} between two functors. And
 indeed, the right hand side of our isomorphism is a functor. It's a
-functor from \code{{[}C, Set{]} × C} to $\Set$. Its action on
-a pair \code{(F, a)} is a set --- the result of evaluating the
-functor \code{F} at the object \code{a}. This is called the
+functor from $[\cat{C}, \Set] \times C$ to $\Set$. Its action on
+a pair $(F, a)$ is a set --- the result of evaluating the
+functor $F$ at the object $a$. This is called the
 evaluation functor.
 
-The left hand side is also a functor that takes \code{(F, a)} to a
-set of natural transformations \code{{[}C, Set{]}(C(a, -), F)}.
+The left hand side is also a functor that takes $(F, a)$ to a
+set of natural transformations $[\cat{C}, \Set](C(a, -), F)$.
 
 To show that these are really functors, we should also define their
 action on morphisms. But what's a morphism between a pair
-\code{(F, a)} and \code{(G, b)}? It's a pair of morphisms,
-\code{(Φ, f)}; the first being a morphism between functors --- a
+$(F, a)$ and $(G, b)$? It's a pair of morphisms,
+$(Φ, f)$; the first being a morphism between functors --- a
 natural transformation --- the second being a regular morphism in
-\emph{C}.
+$\cat{C}$.
 
-The evaluation functor takes this pair \code{(Φ, f)} and maps it to a
-function between two sets, \code{F a} and \code{G b}. We can
-easily construct such a function from the component of \code{Φ} at
-\code{a} (which maps \code{F a} to \code{G a}) and the morphism
-\code{f} lifted by \code{G}:
+The evaluation functor takes this pair $(Φ, f)$ and maps it to a
+function between two sets, $F a$ and $G b$. We can
+easily construct such a function from the component of $Φ$ at
+$a$ (which maps $F a$ to $G a$) and the morphism
+$f$ lifted by $G$:
 
 \begin{Verbatim}[commandchars=\\\{\}]
-(G f) ◦ Φ\textsubscript{a}
+(G f) \ensuremath{\circ} Φ\textsubscript{a}
 \end{Verbatim}
-Notice that, because of naturality of \code{Φ}, this is the same as:
+Notice that, because of naturality of $Φ$, this is the same as:
 
 \begin{Verbatim}[commandchars=\\\{\}]
-Φ\textsubscript{b} ◦ (F f)
+Φ\textsubscript{b} \ensuremath{\circ} (F f)
 \end{Verbatim}
 I'm not going to prove the naturality of the whole isomorphism --- after
 you've established what the functors are, the proof is pretty
@@ -330,7 +330,7 @@ to go wrong.
   preorders? (Question suggested by Gershom Bazerman.)
 \item
   Yoneda embedding can be used to embed an arbitrary functor category
-  \code{{[}C, D{]}} in the functor category
-  \code{{[}{[}C, D{]}, Set{]}}. Figure out how it works on morphisms
+  $[\cat{C}, \cat{D}]$ in the functor category
+  $[[\cat{C}, \cat{D}], \Set]$. Figure out how it works on morphisms
   (which in this case are natural transformations).
 \end{enumerate}


### PR DESCRIPTION
Replaced `code{}` with `$$` and removed redundant
commandchars from verbatim blocks