### PR TITLE
Corrected occasional misspelling of Lawvere and other minor spelling mistakes, and capitalized Cartesian

### DIFF
--- a/src/content/1.10/Natural Transformations.tex
+++ b/src/content/1.10/Natural Transformations.tex
@@ -536,14 +536,14 @@ can construct the latter in $\Cat$.
 As you may remember, in order to construct an exponential, we need to
 first define a product. In $\Cat$, this turns out to be relatively
 easy, because small categories are \emph{sets} of objects, and we know
-how to define cartesian products of sets. So an object in a product
+how to define Cartesian products of sets. So an object in a product
 category $\cat{C\times D}$ is just a pair of objects, $(c, d)$, one from $\cat{C}$
 and one from $\cat{D}$. Similarly, a morphism between two such pairs,
 $(c, d)$ and $(c', d')$, is a pair of morphisms, $(f, g)$, where
 $f \Colon c \to c'$ and $g \Colon d \to d'$. These pairs of morphisms
 compose component-wise, and there is always an identity pair that is
 just a pair of identity morphisms. To make the long story short,
-$\Cat$ is a full-blown cartesian closed category in which there is
+$\Cat$ is a full-blown Cartesian closed category in which there is
 an exponential object $\cat{D^C}$ for any pair of categories.
 And by ``object'' in $\Cat$ I mean a category, so
 $\cat{D^C}$ is a category, which we can identify with the

--- a/src/content/1.5/Products and Coproducts.tex
+++ b/src/content/1.5/Products and Coproducts.tex
@@ -232,7 +232,7 @@ important property of all universal constructions.
 \section{Products}
 
 The next universal construction is that of a product. We know what a
-cartesian product of two sets is: it's a set of pairs. But what's the
+Cartesian product of two sets is: it's a set of pairs. But what's the
 pattern that connects the product set with its constituent sets? If we
 can figure that out, we'll be able to generalize it to other categories.
 
@@ -416,14 +416,14 @@ and so on.
 
 Putting it all together, given any type \code{c} with two projections
 \code{p} and \code{q}, there is a unique \code{m} from \code{c}
-to the cartesian product \code{(a, b)} that factorizes them. In fact,
+to the Cartesian product \code{(a, b)} that factorizes them. In fact,
 it just combines \code{p} and \code{q} into a pair.
 
 \begin{Verbatim}
 m :: c -> (a, b)
 m x = (p x, q x)
 \end{Verbatim}
-That makes the cartesian product \code{(a, b)} our best match, which
+That makes the Cartesian product \code{(a, b)} our best match, which
 means that this universal construction works in the category of sets. It
 picks the product of any two sets.
 

--- a/src/content/1.6/Simple Algebraic Data Types.tex
+++ b/src/content/1.6/Simple Algebraic Data Types.tex
@@ -111,7 +111,7 @@ can be defined alternatively as:
 \begin{Verbatim}
 data Pair a b = P a b
 \end{Verbatim}
-Here, \code{Pair a b} is the name of the type paremeterized by two
+Here, \code{Pair a b} is the name of the type parameterized by two
 other types, \code{a} and \code{b}; and \code{P} is the name of
 the data constructor. You define a pair type by passing two types to the
 \code{Pair} type constructor. You construct a pair value by passing

--- a/src/content/1.6/Simple Algebraic Data Types.tex
+++ b/src/content/1.6/Simple Algebraic Data Types.tex
@@ -100,7 +100,7 @@ rho_inv x = (x, ())
 These observations can be formalized by saying that $\Set$ (the
 category of sets) is a \newterm{monoidal category}. It's a category that's
 also a monoid, in the sense that you can multiply objects (here, take
-their cartesian product). I'll talk more about monoidal categories, and
+their Cartesian product). I'll talk more about monoidal categories, and
 give the full definition in the future.
 
 There is a more general way of defining product types in Haskell ---

--- a/src/content/1.8/Functoriality.tex
+++ b/src/content/1.8/Functoriality.tex
@@ -13,7 +13,7 @@ function of two arguments, you can have a functor of two arguments, or a
 \newterm{bifunctor}. On objects, a bifunctor maps every pair of objects,
 one from category $\cat{C}$, and one from category $\cat{D}$, to an object in category
 $\cat{E}$. Notice that this is just saying that it's a mapping from a
-\newterm{cartesian product} of categories $\cat{C}\times{}\cat{D}$ to $\cat{E}$. 
+\newterm{Cartesian product} of categories $\cat{C}\times{}\cat{D}$ to $\cat{E}$. 
 \begin{wrapfigure}[11]{R}{0pt}
 \raisebox{0pt}[\dimexpr\height-0.75\baselineskip\relax]{
 \includegraphics[width=50mm]{images/bifunctor.jpg}}
@@ -25,13 +25,13 @@ has to map morphisms as well. This time, though, it must map a pair of
 morphisms, one from $\cat{C}$ and one from $\cat{D}$, to a morphism in $\cat{E}$.
 
 Again, a pair of morphisms is just a single morphism in the product
-category $\cat{C}\times{}\cat{D}$ to $\cat{E}$. We define a morphism in a cartesian product of categories
+category $\cat{C}\times{}\cat{D}$ to $\cat{E}$. We define a morphism in a Cartesian product of categories
 as a pair of morphisms which goes from one pair of objects to another
 pair of objects. These pairs of morphisms can be composed in the obvious
 way:
 \[(f, g) \circ (f', g') = (f \circ f', g \circ g')\]
 The composition is associative and it has an identity --- a pair of
-identity morphisms $(\id, \id)$. So a cartesian product of categories
+identity morphisms $(\id, \id)$. So a Cartesian product of categories
 is indeed a category.
 
 But an easier way to think about bifunctors is that they are functors in
@@ -148,7 +148,7 @@ This code also writes itself.
 Now, remember when we talked about monoidal categories? A monoidal
 category defines a binary operator acting on objects, together with a
 unit object. I mentioned that $\Set$ is a monoidal category with
-respect to cartesian product, with the singleton set as a unit. And it's
+respect to Cartesian product, with the singleton set as a unit. And it's
 also a monoidal category with respect to disjoint union, with the empty
 set as a unit. What I haven't mentioned is that one of the requirements
 for a monoidal category is that the binary operator be a bifunctor. This

--- a/src/content/1.8/Functoriality.tex
+++ b/src/content/1.8/Functoriality.tex
@@ -702,7 +702,7 @@ data Fst a b = Fst a
 data Snd a b = Snd b
 \end{Verbatim}
 
-  For additional credit, check your solutions agains Conor McBride's
+  For additional credit, check your solutions against Conor McBride's
   paper \href{http://strictlypositive.org/CJ.pdf}{Clowns to the Left of
   me, Jokers to the Right}.
 \item

--- a/src/content/1.9/Function Types.tex
+++ b/src/content/1.9/Function Types.tex
@@ -378,10 +378,10 @@ categorical exponential object --- which corresponds more to our idea of
 Although I will continue using the category of sets as a model for types
 and functions, it's worth mentioning that there is a larger family of
 categories that can be used for that purpose. These categories are
-called \newterm{cartesian closed}, and $\Set$ is just one example of
+called \newterm{Cartesian closed}, and $\Set$ is just one example of
 such a category.
 
-A cartesian closed category must contain:
+A Cartesian closed category must contain:
 
 \begin{enumerate}
 \tightlist
@@ -393,18 +393,18 @@ A cartesian closed category must contain:
   An exponential for any pair of objects.
 \end{enumerate}
 If you consider an exponential as an iterated product (possibly
-infinitely many times), then you can think of a cartesian closed
+infinitely many times), then you can think of a Cartesian closed
 category as one supporting products of an arbitrary arity. In
 particular, the terminal object can be thought of as a product of zero
 objects --- or the zero-th power of an object.
 
-What's interesting about cartesian closed categories from the
+What's interesting about Cartesian closed categories from the
 perspective of computer science is that they provide models for the
 simply typed lambda calculus, which forms the basis of all typed
 programming languages.
 
 The terminal object and the product have their duals: the initial object
-and the coproduct. A cartesian closed category that also supports those
+and the coproduct. A Cartesian closed category that also supports those
 two, and in which product can be distributed over coproduct
 \begin{gather*}
 a \times (b + c) = a \times b + a \times c \\

--- a/src/content/2.1/Declarative Programming.tex
+++ b/src/content/2.1/Declarative Programming.tex
@@ -190,7 +190,7 @@ factorizing the projections of other such objects.
 Compare this with Fermat's principle of minimum time, or the principle
 of least action.
 
-Conversely, contrast this with the traditional definition of a cartesian
+Conversely, contrast this with the traditional definition of a Cartesian
 product, which is much more imperative. You describe how to create an
 element of the product by picking one element from one set and another
 element from another set. It's a recipe for creating a pair. And there's

--- a/src/content/2.4/Representable Functors.tex
+++ b/src/content/2.4/Representable Functors.tex
@@ -306,7 +306,7 @@ to $\Set$, because $\cat{C}^{op}(a, -)$ is the same as
 $\cat{C}(-, a)$.
 
 There is an interesting twist to representability. Remember that
-hom-sets can internally be treated as exponential objects, in cartesian
+hom-sets can internally be treated as exponential objects, in Cartesian
 closed categories. The hom-set $\cat{C}(a, x)$ is equivalent to
 $x^a$, and for a representable functor $F$ we can write: $-a = F$.
 

--- a/src/content/2.4/Representable Functors.tex
+++ b/src/content/2.4/Representable Functors.tex
@@ -14,7 +14,7 @@ stick to categories with good old-fashioned hom-sets.
 A set is the closest thing to a featureless blob you can get outside of
 categorical objects. A set has elements, but you can't say much about
 these elements. If you have a finite set, you can count the elements.
-You can kind of count the elements of an inifinite set using cardinal
+You can kind of count the elements of an infinite set using cardinal
 numbers. The set of natural numbers, for instance, is smaller than the
 set of real numbers, even though both are infinite. But, maybe
 surprisingly, a set of rational numbers is the same size as the set of
@@ -136,7 +136,7 @@ instance Profunctor (->) where
 The important lesson is that this observation holds in any category: the
 mapping of objects to hom-sets is functorial. Since contravariance is
 equivalent to a mapping from the opposite category, we can state this
-fact succintly as:
+fact succinctly as:
 \[C(-, =) \Colon \cat{C}^{op} \times \cat{C} \to \Set\]
 
 \section{Representable Functors}

--- a/src/content/2.5/The Yoneda Lemma.tex
+++ b/src/content/2.5/The Yoneda Lemma.tex
@@ -2,7 +2,7 @@
 from other more specific areas of mathematics. Things like products,
 coproducts, monoids, exponentials, etc., have been known long before
 category theory. They might have been known under different names in
-different branches of mathematics. A cartesian product in set theory, a
+different branches of mathematics. A Cartesian product in set theory, a
 meet in order theory, a conjunction in logic --- they are all specific
 examples of the abstract idea of a categorical product.
 

--- a/src/content/3.10/Ends and Coends.tex
+++ b/src/content/3.10/Ends and Coends.tex
@@ -114,7 +114,7 @@ particular, the coend may be understood as an infinite sum or an
 integral, whereas the end is similar to an infinite product. There is
 even something that resembles the Dirac delta function.
 
-An end is a genaralization of a limit, with the functor replaced by a
+An end is a generalization of a limit, with the functor replaced by a
 profunctor. Instead of a cone, we have a wedge. The base of a wedge is
 formed by diagonal elements of a profunctor $p$. The apex of the
 wedge is an object (here, a set, since we are considering
@@ -144,7 +144,7 @@ Or, using Haskell notation:
 dimap id f . alpha = dimap f id . alpha
 \end{Verbatim}
 We can now proceed with the universal construction and define the end of
-$p$ as the uinversal wedge --- a set $e$ together with a
+$p$ as the universal wedge --- a set $e$ together with a
 family of functions $\pi$ such that for any other wedge with the
 apex $a$ and a family $\alpha$ there is a unique function
 $h \Colon a \to e$ that makes all triangles commute:
@@ -479,7 +479,7 @@ data Procompose q p a b where
 \end{Verbatim}
 This is using generalized algebraic data type, or \acronym{GADT} syntax, in which
 a free type variable (here \code{c}) is automatically existentially
-quanitified. The (uncurried) data constructor \code{Procompose} is
+quantified. The (uncurried) data constructor \code{Procompose} is
 thus equivalent to:
 
 \begin{Verbatim}

--- a/src/content/3.10/Ends and Coends.tex
+++ b/src/content/3.10/Ends and Coends.tex
@@ -466,7 +466,7 @@ intermediary object $c$ such that both $q\ b\ c$ and
 $p\ c\ a$ are non-empty. The proofs of this new relation are all
 pairs of proofs of individual relations. Therefore, with the
 understanding that the existential quantifier corresponds to a coend,
-and the cartesian product of two sets corresponds to ``pairs of
+and the Cartesian product of two sets corresponds to ``pairs of
 proofs,'' we can define composition of profunctors using the following
 formula:
 \[(q \circ p)\ a\ b = \int^c p\ c\ a\times{}q\ b\ c\]

--- a/src/content/3.11/Kan Extensions.tex
+++ b/src/content/3.11/Kan Extensions.tex
@@ -177,7 +177,7 @@ that, one more condition is necessary: the right Kan extension must be
 preserved by the functor $K$. The preservation of the extension
 means that, if we calculate the Kan extension of the functor precomposed
 with $K$, we should get the same result as precomposing the
-original Kan extesion with $K$. In our case, this condition
+original Kan extension with $K$. In our case, this condition
 simplifies to:
 \[K \circ \Ran_{K}I_{\cat{C}} \cong \Ran_{K}K\]
 Notice that, using the division-by-$K$ notation, the adjunction can be

--- a/src/content/3.12/Enriched Categories.tex
+++ b/src/content/3.12/Enriched Categories.tex
@@ -226,7 +226,7 @@ An interesting example is due to
 Lawvere}. He noticed that metric spaces can be defined using enriched
 categories. A metric space defines a distance between any two objects.
 This distance is a non-negative real number. It's convenient to include
-inifinity as a possible value. If the distance is infinite, there is no
+infinity as a possible value. If the distance is infinite, there is no
 way of getting from the starting object to the target object.
 
 There are some obvious properties that have to be satisfied by

--- a/src/content/3.12/Enriched Categories.tex
+++ b/src/content/3.12/Enriched Categories.tex
@@ -48,9 +48,9 @@ pair of morphisms, one from $\cat{C}(b, c)$ and one from
 $\cat{C}(a, b)$ and maps it to a morphism from $\cat{C}(a, c)$. In
 other words it's a mapping:
 \[\cat{C}(b, c)\times{}\cat{C}(a, b) \to \cat{C}(a, c)\]
-This is a function between sets --- one of them being the cartesian
+This is a function between sets --- one of them being the Cartesian
 product of two hom-sets. This formula can be easily generalized by
-replacing cartesian product with something more general. A categorical
+replacing Cartesian product with something more general. A categorical
 product would work, but we can go even further and use a completely
 general tensor product.
 
@@ -110,7 +110,7 @@ to define the internal hom (the function object) as the right adjoint to
 the tensor product. You may recall that the standard definition of the
 function object, or the exponential, was through the right adjoint to
 the categorical product. A category in which such an object existed for
-any pair of objects was called cartesian closed. Here is the adjunction
+any pair of objects was called Cartesian closed. Here is the adjunction
 that defines the internal hom in a monoidal category:
 \[\cat{V}(a \otimes b, c) \sim \cat{V}(a, [b, c])\]
 Following
@@ -351,13 +351,13 @@ define $j_a$ as its image under the adjunction.
 
 A practical example of self-enrichment is the category $\Set$ that
 serves as the prototype for types in programming languages. We've seen
-before that it's a closed monoidal category with respect to cartesian
+before that it's a closed monoidal category with respect to Cartesian
 product. In $\Set$, the hom-set between any two sets is itself a
 set, so it's an object in $\Set$. We know that it's isomorphic to
 the exponential set, so the external and the internal homs are
 equivalent. Now we also know that, through self-enrichment, we can use
 the exponential set as the hom-object and express composition in terms
-of cartesian products of exponential objects.
+of Cartesian products of exponential objects.
 
 \section{Relation to $\cat{2}$-Categories}
 

--- a/src/content/3.13/Topoi.tex
+++ b/src/content/3.13/Topoi.tex
@@ -197,7 +197,7 @@ A topos is a category that:
 \begin{enumerate}
 \tightlist
 \item
-  Is cartesian closed: It has all products, the terminal object, and
+  Is Cartesian closed: It has all products, the terminal object, and
   exponentials (defined as right adjoints to products),
 \item
   Has limits for all finite diagrams,

--- a/src/content/3.13/Topoi.tex
+++ b/src/content/3.13/Topoi.tex
@@ -2,7 +2,7 @@
 hard-core math. But you never know what the next big revolution in
 programming might bring and what kind of math might be necessary to
 understand it. There are some very interesting ideas going around, like
-functional reactive programming with its continuous time, the extention
+functional reactive programming with its continuous time, the extension
 of Haskell's type system with dependent types, or the exploration on
 homotopy type theory in programming.
 
@@ -179,7 +179,7 @@ because a pullback is only unique up to isomorphism. But remember our
 earlier definition of a subset as a family of equivalent injections. We
 can generalize it by defining a subobject of $b$ as a family of
 equivalent monomorphisms to $b$. This family of monomorphisms is
-in one-to-one corrpespondence with the family of equivalent pullbacks of
+in one-to-one correspondence with the family of equivalent pullbacks of
 our diagram.
 
 We can thus define a set of subobjects of $b$, $Sub(b)$,

--- a/src/content/3.14/Lawvere Theories.tex
+++ b/src/content/3.14/Lawvere Theories.tex
@@ -286,7 +286,7 @@ from the singleton set to the empty set. No such function exists.
 Next, consider morphisms $2 \to 1$, members of
 $\cat{L}_{\cat{Mon}}(2, 1)$, which must contain prototypes of all binary
 operations. When constructing models in $\cat{Mod}(\cat{L}_{\cat{Mon}}, \Set)$, these
-morphisms will be mapped to functions from the cartesian product
+morphisms will be mapped to functions from the Cartesian product
 $M\ 1 \times M\ 1$ to $M\ 1$. In other words, functions of
 two arguments.
 

--- a/src/content/3.14/Lawvere Theories.tex
+++ b/src/content/3.14/Lawvere Theories.tex
@@ -69,7 +69,7 @@ the roadmap:
 \includegraphics[width=90mm]{images/lawvere1.png}
 \end{figure}
 
-\section{Lavwere Theories}
+\section{Lawvere Theories}
 
 All Lawvere theories share a common backbone. All objects in a Lawvere
 theory are generated from just one object using products (really, just
@@ -109,7 +109,7 @@ being the initial object), no morphisms from $n$ to $\varnothing$
 $n$ (the injections), one morphism from $n$ to $1$,
 and so on. Here, $n$ denotes an object in $\cat{F}$
 corresponding to all $n$-element sets in $\cat{FinSet}$ that have been
-identified through isomorphims.
+identified through isomorphisms.
 
 Using the category $\cat{F}$ we can formally define a \newterm{Lawvere
 theory} as a category $\cat{L}$ equipped with a special functor
@@ -170,7 +170,7 @@ the ``interesting'' morphisms that describe the $n$-ary operations (dotted
 arrows).}
 \end{figure}
 
-Lavwere theories form a category $\cat{Law}$, in which morphisms are
+Lawvere theories form a category $\cat{Law}$, in which morphisms are
 functors that preserve finite products and commute with the functors
 $I$. Given two such theories, $(\cat{L}, I_{\cat{L}})$ and
 $(\cat{L'}, I'_{\cat{L'}})$, a morphism between them is a
@@ -333,7 +333,7 @@ $\cat{L}$.
 
 Another way of deriving $U$ is by exploiting the fact that
 $\Fop$ is the initial object in $\cat{Law}$. It
-meanst that, for any Lawvere theory $\cat{L}$, there is a unique
+means that, for any Lawvere theory $\cat{L}$, there is a unique
 functor $\Fop \to L$. This functor induces the
 opposite functor on models (since models are functors \emph{from}
 theories to sets):
@@ -374,7 +374,7 @@ that can be used to generate expressions. Models provide means to
 evaluate these expressions.
 
 The connection between monads and Lawvere theories doesn't go both ways,
-though. Only finitary monads lead to Lawvere thories. A finitary monad
+though. Only finitary monads lead to Lawvere theories. A finitary monad
 is based on a finitary functor. A finitary functor on $\Set$ is
 fully determined by its action on finite sets. Its action on an
 arbitrary set $a$ can be evaluated using the following coend:
@@ -590,7 +590,7 @@ not their handling.
 \begin{enumerate}
 \tightlist
 \item
-  Enumarate all morphisms between $2$ and $3$ in $\cat{F}$ (the skeleton of
+  Enumerate all morphisms between $2$ and $3$ in $\cat{F}$ (the skeleton of
   $\cat{FinSet}$).
 \item
   Show that the category of models for the Lawvere theory of monoids is

--- a/src/content/3.15/Monads, Monoids, and Categories.tex
+++ b/src/content/3.15/Monads, Monoids, and Categories.tex
@@ -15,7 +15,7 @@ interconnections might be a good way to end this book.
 One of the most difficult aspects of category theory is the constant
 switching of perspectives. Take the category of sets, for instance. We
 are used to defining sets in terms of elements. An empty set has no
-elements. A singleton set has one element. A cartesian product of two
+elements. A singleton set has one element. A Cartesian product of two
 sets is a set of pairs, and so on. But when talking about the category
 $\Set$ I asked you to forget about the contents of sets and
 instead concentrate on morphisms (arrows) between them. You were
@@ -160,7 +160,7 @@ which is universal among all such objects.
 \noindent
 For now, let's concentrate on spans over the category of sets. In that
 case, the pullback is just a set of pairs $(p, q)$ from the
-cartesian product $x \times y$ such that:
+Cartesian product $x \times y$ such that:
 \[g\ p = f'\ q\]
 A morphism between two spans that share the same endpoints is defined as
 a morphism $h$ between their apices, such that the appropriate

--- a/src/content/3.4/Monads - Programmer's Definition.tex
+++ b/src/content/3.4/Monads - Programmer's Definition.tex
@@ -123,7 +123,7 @@ identity arrow for every object, then the functor $m$ is called a
 \newterm{monad}, and the resulting category is called the Kleisli category.
 
 In Haskell, Kleisli composition is defined using the fish operator
-\code{>=>}, and the identity arrrow is a
+\code{>=>}, and the identity arrow is a
 polymorphic function called \code{return}. Here's the definition of a
 monad using Kleisli composition:
 

--- a/src/content/3.6/Monads Categorically.tex
+++ b/src/content/3.6/Monads Categorically.tex
@@ -238,7 +238,7 @@ mu x (mu y z) = mu (mu x y) z
 Before we can generalize it to other categories, we have to rewrite it
 as an equality of functions (morphisms). We have to abstract it away
 from its action on individual variables --- in other words, we have to
-use point-free notation. Knowning that the cartesian product is a
+use point-free notation. Knowing that the cartesian product is a
 bifunctor, we can write the left hand side as:
 
 \begin{Verbatim}

--- a/src/content/3.6/Monads Categorically.tex
+++ b/src/content/3.6/Monads Categorically.tex
@@ -199,11 +199,11 @@ started with a different definition of multiplication:
 \begin{Verbatim}
 mu :: (m, m) -> m
 \end{Verbatim}
-Here, the cartesian product \code{(m, m)} becomes the source of pairs
+Here, the Cartesian product \code{(m, m)} becomes the source of pairs
 to be multiplied.
 
 This definition suggests a different path to generalization: replacing
-the cartesian product with categorical product. We could start with a
+the Cartesian product with categorical product. We could start with a
 category where products are globally defined, pick an object \code{m}
 there, and define multiplication as a morphism:
 \[\mu \Colon m\times{}m \to m\]
@@ -238,7 +238,7 @@ mu x (mu y z) = mu (mu x y) z
 Before we can generalize it to other categories, we have to rewrite it
 as an equality of functions (morphisms). We have to abstract it away
 from its action on individual variables --- in other words, we have to
-use point-free notation. Knowing that the cartesian product is a
+use point-free notation. Knowing that the Cartesian product is a
 bifunctor, we can write the left hand side as:
 
 \begin{Verbatim}
@@ -249,7 +249,7 @@ and the right hand side as:
 \begin{Verbatim}
 (mu . bimap mu id)((x, y), z)
 \end{Verbatim}
-This is almost what we want. Unfortunately, the cartesian product is not
+This is almost what we want. Unfortunately, the Cartesian product is not
 strictly associative --- \code{(x, (y, z))} is not the same as
 \code{((x, y), z)} --- so we can't just write point-free:
 
@@ -283,7 +283,7 @@ They can be rewritten as:
 \end{Verbatim}
 The isomorphisms \code{lambda} and \code{rho} are called the left
 and right unitor, respectively. They witness the fact that the unit
-\code{()} is the identity of the cartesian product up to isomorphism:
+\code{()} is the identity of the Cartesian product up to isomorphism:
 
 \begin{Verbatim}
 lambda :: ((), a) -> a
@@ -300,9 +300,9 @@ mu . bimap id eta = lambda
 mu . bimap eta id = rho
 \end{Verbatim}
 We have formulated point-free monoidal laws for \code{mu} and
-\code{eta} using the fact that the underlying cartesian product itself
+\code{eta} using the fact that the underlying Cartesian product itself
 acts like a monoidal multiplication in the category of types. Keep in
-mind though that the associativity and unit laws for the cartesian
+mind though that the associativity and unit laws for the Cartesian
 product are valid only up to isomorphism.
 
 It turns out that these laws can be generalized to any category with

--- a/src/content/3.7/Comonads.tex
+++ b/src/content/3.7/Comonads.tex
@@ -146,7 +146,7 @@ way of converting the resulting \code{b} to \code{w b}. Remember,
 the comonad provides no means of lifting values. At this point, in the
 analogous construction for monads, we used \code{fmap}. The only way
 we could use \code{fmap} here would be if we had something of the type
-\code{w (w a)} at our disposal. If we coud only turn \code{w a}
+\code{w (w a)} at our disposal. If we could only turn \code{w a}
 into\\ \code{w (w a)}. And, conveniently, that would be exactly the
 dual of \code{join}. We call it \code{duplicate}:
 

--- a/src/content/3.8/F-Algebras.tex
+++ b/src/content/3.8/F-Algebras.tex
@@ -359,7 +359,7 @@ is known as the Peano representation for natural numbers.
 \section{Catamorphisms}
 
 Let's rewrite the initiality condition using Haskell notation. We call
-the initial algebra \code{Fix f}. Its evaluator is the contructor
+the initial algebra \code{Fix f}. Its evaluator is the constructor
 \code{Fix}. There is a unique morphism \code{m} from the initial
 algebra to any other algebra over the same functor. Let's pick an
 algebra whose carrier is \code{a} and the evaluator is \code{alg}.

--- a/src/content/3.8/F-Algebras.tex
+++ b/src/content/3.8/F-Algebras.tex
@@ -15,15 +15,15 @@ $m$. Not every choice of two functions with these signatures
 results in a monoid. For that we need to impose additional conditions:
 associativity and unit laws. But let's forget about that for a moment
 and just consider ``potential monoids.'' A pair of functions is an
-element of a cartesian product of two sets of functions. We know that
+element of a Cartesian product of two sets of functions. We know that
 these sets may be represented as exponential objects:
 \begin{align*}
 \mu &\in m^{m\times{}m} \\
 \eta &\in m^1
 \end{align*}
-The cartesian product of these two sets is:
+The Cartesian product of these two sets is:
 \[m^{m\times{}m}\times{}m^1\]
-Using some high-school algebra (which works in every cartesian closed
+Using some high-school algebra (which works in every Cartesian closed
 category), we can rewrite it as:
 \[m^{m\times{}m + 1}\]
 The $+$ sign stands for the coproduct in $\Set$. We have just
@@ -61,9 +61,9 @@ Now we can go crazy with generalizations. First of all, we can replace
 sets with objects and functions with morphisms. We can define n-ary
 operators as morphisms from n-ary products. It means that we need a
 category that supports finite products. For nullary operators we require
-the existence of the terminal object. So we need a cartesian category.
+the existence of the terminal object. So we need a Cartesian category.
 In order to combine these operators we need exponentials, so that's a
-cartesian closed category. Finally, we need coproducts to complete our
+Cartesian closed category. Finally, we need coproducts to complete our
 algebraic shenanigans.
 
 Alternatively, we can just forget about the way we derived our formulas

--- a/src/content/3.9/Algebras for Monads.tex
+++ b/src/content/3.9/Algebras for Monads.tex
@@ -121,7 +121,7 @@ we can use the monadic $\mu_a$ (\code{join} in Haskell) as the
 evaluator.
 
 We still have to show that this is a T-algebra. For that, two coherence
-conditions must be satisified:
+conditions must be satisfied:
 \begin{align*}
 alg &\circ \eta_{Ta} = \id_{Ta} \\
 alg &\circ \mu_a = alg \circ T\ alg
@@ -177,7 +177,7 @@ $\varepsilon$ at $(a, f)$ (an object in the category of T-algebras)
 to be $f$.
 
 To complete the adjunction we also need to show that the unit and the
-counit satisfy triangular identites. These are:
+counit satisfy triangular identities. These are:
 
 \begin{figure}[H]
 \centering
@@ -200,7 +200,7 @@ $F^T$ drops the evaluator. So, indeed, we have:
 As expected, the unit of the adjunction is the unit of the monad $T$.
 
 You may remember that the counint of the adjunction produces monadic
-muliplication through the following formula:
+multiplication through the following formula:
 \[\mu = R \circ \varepsilon \circ L\]
 This is a horizontal composition of three natural transformations, two
 of them being identity natural transformations mapping, respectively,


### PR DESCRIPTION
I made some minor spelling corrections.

Note: unfortunately my editor feels that every line, including the last one, should end with a newline character so the last line of each file I changed also shows as changed in the diffs.

I did also start correcting "cartesian" (spelled with a small "c") to "Cartesian" but then decided to leave this alone. Using a capital "C" however does seem to be the norm, e.g. if you look at [Cartesian product on Wikipedia](https://en.wikipedia.org/wiki/Cartesian_product) or on [Wolfram](http://mathworld.wolfram.com/CartesianProduct.html).