### PR TITLE
Fix a typo in the category of a morphism on morphisms.

### DIFF
--- a/src/content/1.10/Natural Transformations.tex
+++ b/src/content/1.10/Natural Transformations.tex
@@ -615,7 +615,7 @@ respectively, on functors $F$ and $G$:
 \noindent
 Notice that we cannot apply vertical composition to this pair, because
 the target of $\alpha$ is different from the source of $\beta$. In fact they are
-members of two different functor categories: $\cat{D^E}$ and $\cat{E^D}$.
+members of two different functor categories: $\cat{D^C}$ and $\cat{E^D}$.
 We can, however, apply composition to the functors
 $F'$ and $G'$, because the target of $F'$ is the source of $G'$ --- it's the
 category $\cat{D}$. What's the relation between the functors $G' \circ F'$ and $G \circ F$?


### PR DESCRIPTION
Fixes issue #91.

I believe there is a typo in section 10.4 2-Categories. The sentence "In fact they are members of two different functor categories:" is followed by categories `D^E` and `E^D`. I believe the intent was `D^C` and `E^D` as we are talking about the morphisms on morphisms α and β, with :
```
α :: F → F′
β :: G → G′
F :: C → D
G :: D → E```