### PR TITLE
Minor typos

### DIFF
--- a/src/content/1.10/Natural Transformations.tex
+++ b/src/content/1.10/Natural Transformations.tex
@@ -523,7 +523,7 @@ $\cat{Cat(C, D)}$ is a set of functors between two categories $\cat{C}$ and $\ca
 \includegraphics[width=40mm]{images/7_cathomset.jpg}
 \end{figure}
 
-A functor category $\cat{[}C, D{]}$ is also a set of functors between two
+A functor category $\cat{{[}C, D{]}}$ is also a set of functors between two
 categories (plus natural transformations as morphisms). Its objects are
 the same as the members of $\cat{Cat(C, D)}$. Moreover, a functor category,
 being a category, must itself be an object of $\Cat$ (it so

--- a/src/content/1.6/Simple Algebraic Data Types.tex
+++ b/src/content/1.6/Simple Algebraic Data Types.tex
@@ -319,7 +319,7 @@ can be either null, or point to a value of specific type. For instance,
 a Haskell list type, which can be defined as a (recursive) sum type:
 
 \begin{Verbatim}
-List a = Nil | Cons a (List a)
+data List a = Nil | Cons a (List a)
 \end{Verbatim}
 can be translated to C++ using the null pointer trick to implement the
 empty list:

--- a/src/content/1.9/Function Types.tex
+++ b/src/content/1.9/Function Types.tex
@@ -526,7 +526,7 @@ data types. The \code{Void} type and the unit type \code{()}
 correspond to false and true. Product types and sum types correspond to
 logical conjunction $\wedge$ (AND) and disjunction $\vee$ (OR). In this scheme, the
 function type we have just defined corresponds to logical implication $\Rightarrow$.
-In other words, the type \code{$a -> b$} can be read as ``if
+In other words, the type \code{a -> b} can be read as ``if
 a then b.''
 
 According to the Curry-Howard isomorphism, every type can be interpreted


### PR DESCRIPTION
And the addition of a `data` for a Haskell valid structure (the examples right before are also using it, I think it makes sense to be consistent)