### PR TITLE
shell.nix: pin nixpkgs to recent 18.03

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,13 @@
 # nix-shell --pure shell.nix --command 'cd src; make'
-{ pkgs ? import <nixpkgs> {} }: with pkgs;
+let
+  rev = "4df3426f5a5e78cef4835897a43abd9e2a092b74";
+  sha256 = "05k5mssiqxffxi45mss9wjns6k76i248rpasa48akdcriry1mp63";
+  nixpkgs = builtins.fetchTarball {
+    inherit sha256;
+    url = "https://github.com/NixOS/nixpkgs-channels/archive/${rev}.tar.gz";
+  };
+in
+{ pkgs ? import nixpkgs {} }: with pkgs;
 
 mkShell {
   FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ inconsolata-lgc libertine libertinus ]; };


### PR DESCRIPTION
This is needed to ensure the use of TeX Live 2017, see [this tweet](https://twitter.com/hmemcpy/status/1033352444280033280) for details.