### PR TITLE
Using \mathcal for calligraphic representation of categories

### DIFF
--- a/src/category.tex
+++ b/src/category.tex
@@ -7,10 +7,11 @@
 \newcommand{\Lim}[1][]{%
 \mathbf{Lim}{#1}%
 }
-\newcommand{\Set}{\cat{Set}}
-\newcommand{\Rel}{\cat{Rel}}
-\newcommand{\Cat}{\cat{Cat}}
+\newcommand{\Set}{\mathcal{S\mkern-3mu et}}
+\newcommand{\Rel}{\mathcal{R\mkern-3mu el}}
+\newcommand{\Cat}{\mathcal{C\mkern-3mu at}}
 \newcommand{\id}{\mathbf{id}}
-\newcommand{\Ran}{\mathbf{Ran}}
-\newcommand{\Lan}{\mathbf{Lan}}
+\newcommand{\Ran}{\mathcal{R\mkern-3mu an}}
+\newcommand{\Lan}{\mathcal{L\mkern-3mu an}}
 \newcommand{\Fop}{\cat{F}^{op}}
+\newcommand{\Hask}{\mathcal{H\mkern-3mu ask}}

--- a/src/content/1.10/Natural Transformations.tex
+++ b/src/content/1.10/Natural Transformations.tex
@@ -408,7 +408,7 @@ We can write a polymorphic function from, say, \code{Op Bool} to
 predToStr (Op f) = Op (\x -> if f x then "T" else "F")
 \end{Verbatim}
 But since the two functors are not covariant, this is not a natural
-transformation in \textbf{Hask}. However, because they are both
+transformation in $\Hask$. However, because they are both
 contravariant, they satisfy the ``opposite'' naturality condition:
 
 \begin{Verbatim}

--- a/src/content/1.2/Types and Functions.tex
+++ b/src/content/1.2/Types and Functions.tex
@@ -184,7 +184,7 @@ the theoretical point of view, this is the source of never-ending
 complications, so at this point I will use my butcher's knife and
 terminate this line of reasoning. From the pragmatic point of view, it's
 okay to ignore non-terminating functions and bottoms, and treat
-\textbf{Hask} as bona fide $\Set$.\footnote{Nils Anders Danielsson,
+$\Hask$ as bona fide $\Set$.\footnote{Nils Anders Danielsson,
 John Hughes, Patrik Jansson, Jeremy Gibbons, \href{http://www.cs.ox.ac.uk/jeremy.gibbons/publications/fast+loose.pdf}{
 Fast and Loose Reasoning is Morally Correct}. This paper provides justification for ignoring bottoms in most contexts.}
 

--- a/src/content/1.3/Categories Great and Small.tex
+++ b/src/content/1.3/Categories Great and Small.tex
@@ -170,7 +170,7 @@ produced by functions, as in:
 mappend s1 s2 = (++) s1 s2
 \end{Verbatim}
 The former translates into equality of morphisms in the category
-\textbf{Hask} (or $\Set$, if we ignore bottoms, which is the name
+$\Hask$ (or $\Set$, if we ignore bottoms, which is the name
 for never-ending calculations). Such equations are not only more
 succinct, but can often be generalized to other categories. The latter
 is called \newterm{extensional} equality, and states the fact that for any

--- a/src/content/3.2/Adjunctions.tex
+++ b/src/content/3.2/Adjunctions.tex
@@ -209,7 +209,7 @@ pair of adjoint functors --- this factorization is not unique, though.
 
 In Haskell, we use monads a lot, but only rarely factorize them into
 pairs of adjoint functors, primarily because those functors would
-normally take us out of $\cat{Hask}$.
+normally take us out of $\Hask$.
 
 We can however define adjunctions of \newterm{endofunctors} in Haskell.
 Here's part of the definition taken from
@@ -423,7 +423,7 @@ We have a mapping that takes a pair of morphisms \code{p} and
 
 How can we translate this into a mapping between two hom-sets that we
 need to define an adjunction? The trick is to go outside of
-\textbf{Hask} and treat the pair of morphisms as a single morphism in
+$\Hask$ and treat the pair of morphisms as a single morphism in
 the product category.
 
 Let me remind you what a product category is. Take two arbitrary

--- a/src/content/3.5/Monads and Effects.tex
+++ b/src/content/3.5/Monads and Effects.tex
@@ -95,9 +95,9 @@ this value is not explicitly needed (for instance, to be pattern
 matched, or produced as output), it may be passed around without
 stalling the execution of the program. Because every Haskell function
 may be potentially non-terminating, all types in Haskell are assumed to
-be lifted. This is why we often talk about the category $\cat{Hask}$ of
+be lifted. This is why we often talk about the category $\Hask$ of
 Haskell (lifted) types and functions rather than the simpler
-$\Set$. It is not clear, though, that $\cat{Hask}$ is a real
+$\Set$. It is not clear, though, that $\Hask$ is a real
 category (see this
 \urlref{http://math.andrej.com/2016/08/06/hask-is-not-a-category/}{Andrej
 Bauer post}).

--- a/src/content/3.6/Monads Categorically.tex
+++ b/src/content/3.6/Monads Categorically.tex
@@ -56,7 +56,7 @@ endofunctors).
 The component of this natural transformation at an object $a$ is
 the morphism:
 \[\mu_a \Colon T (T a) \to T a\]
-which, in $\cat{Hask}$, translates directly to our definition of
+which, in $\Hask$, translates directly to our definition of
 \code{join}.
 
 $\eta$ is a natural transformation between the identity functor $I$

--- a/src/preamble.tex
+++ b/src/preamble.tex
@@ -30,6 +30,10 @@
 % Needed to display additional math unicode symbols (like double-colon)
 \usepackage{unicode-math}
 \setmathfont{Libertinus Math}
+\DeclareFontFamily{U}{mathc}{}
+\DeclareFontShape{U}{mathc}{m}{it}%
+{<->s*[1.03] mathc10}{}
+\DeclareMathAlphabet{\mathcal}{U}{mathc}{m}{it}
 
 \usepackage[all]{nowidow}
 \usepackage{emptypage}


### PR DESCRIPTION
Fixes #140

![image](https://user-images.githubusercontent.com/601206/45138579-9ada6100-b1b5-11e8-9795-b431a905ba78.png)

On one hand, it's nice. Also consistent with other texts on category theory, which uses this font for categories.
On the other hand, it's a bit weird in this context, as this book is aimed for programmers who may not be accustomed to seeing this font, and it would look out of place (I hadn't done it for everything, just "named" category terms: Hask, Set, Kan, etc.).

@BartoszMilewski, WDYT?