### PR TITLE
Texlive 2018 support

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -40,6 +40,7 @@ mkShell {
         chngcntr
         ifplatform
         xstring
+        minifp
         enumitem;
       })
     gnumake

--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,5 @@
 # nix-shell --pure shell.nix --command 'cd src; make'
-let
-  rev = "4df3426f5a5e78cef4835897a43abd9e2a092b74";
-  sha256 = "05k5mssiqxffxi45mss9wjns6k76i248rpasa48akdcriry1mp63";
-  nixpkgs = builtins.fetchTarball {
-    inherit sha256;
-    url = "https://github.com/NixOS/nixpkgs-channels/archive/${rev}.tar.gz";
-  };
-in
-{ pkgs ? import nixpkgs {} }: with pkgs;
+{ pkgs ? import <nixpkgs> {} }: with pkgs;
 
 mkShell {
   FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ inconsolata-lgc libertine libertinus ]; };

--- a/src/preamble.tex
+++ b/src/preamble.tex
@@ -34,6 +34,11 @@
 \usepackage[libertine]{newtxmath}
 \usepackage{amsmath}
 % Needed to display additional math unicode symbols (like double-colon)
+
+% https://github.com/wspr/unicode-math/issues/469
+\expandafter\let\csname not=\endcsname\relax
+\expandafter\let\csname not<\endcsname\relax
+\expandafter\let\csname not>\endcsname\relax
 \usepackage{unicode-math}
 \setmathfont{Libertinus Math}
 


### PR DESCRIPTION
Fixes #144 (and fixes #124)
Reverts a pinning change to nix script to pull the latest (2018) TexLive.