### PR TITLE
Fix typo in Chapter 14.

### DIFF
--- a/src/content/2.4/Representable Functors.tex
+++ b/src/content/2.4/Representable Functors.tex
@@ -270,7 +270,7 @@ $\cat{C}(-, a)$.
 There is an interesting twist to representability. Remember that
 hom-sets can internally be treated as exponential objects, in Cartesian
 closed categories. The hom-set $\cat{C}(a, x)$ is equivalent to
-$x^a$, and for a representable functor $F$ we can write: $-a = F$.
+$x^a$, and for a representable functor $F$ we can write: $-^a = F$.
 
 Let's take the logarithm of both sides, just for kicks: $a = \mathbf{log}F$
 


### PR DESCRIPTION
In the chapter on [Representable Functors](https://bartoszmilewski.com/2015/07/29/representable-functors/), what should read as
> -<sup>a</sup> = F

is currently appearing as
> -a = F

I was pretty confused until I looked up the original text. :joy:

------
By the way, thanks for making this—it's been a joy to read on my Kindle!