### PR TITLE
Fix typo in Chapter 19.

### DIFF
--- a/src/content/3.3/Free-Forgetful Adjunctions.tex
+++ b/src/content/3.3/Free-Forgetful Adjunctions.tex
@@ -52,7 +52,7 @@ universal construction we've discussed before.\footnote{See ch.13 on
 \hyperref[free-monoids]{free monoids}.}
 
 In terms of hom-sets, we can write this adjunction as:
-\[\cat{arg}(F x, m) \cong \Set(x, U m)\]
+\[\cat{Mon}(F x, m) \cong \Set(x, U m)\]
 This (natural in $x$ and $m$) isomorphism tells us that:
 
 \begin{itemize}


### PR DESCRIPTION
In the chapter on [Free/Forgetful Adjunctions](https://bartoszmilewski.com/2016/06/15/freeforgetful-adjunctions/), an instance of the category name **Mon** is currently appearing as **arg**. (Looks like the problem was introduced [here](https://github.com/hmemcpy/milewski-ctfp-pdf/commit/51a71ee475724e8201c5d9b62b4ba92bd0471733#diff-a8491c5119dff7c11d41b4edab18ab5cR53).)