### PR TITLE
Fix typos in Chapters 23 and 25.

### DIFF
--- a/src/content/3.7/Comonads.tex
+++ b/src/content/3.7/Comonads.tex
@@ -384,7 +384,7 @@ the type \code{s} as an index. In particular, a function of the type:
 is equivalent to a pair of functions:
 
 \src{code/haskell/snippet39.hs}
-If \code{a} is a product type, $\Set$ could be implemented as
+If \code{a} is a product type, \code{set} could be implemented as
 setting the field of type \code{s} inside of \code{a} while
 returning the modified version of \code{a}. Similarly, \code{get}
 could be implemented to read the value of the \code{s} field from

--- a/src/content/3.9/Algebras for Monads.tex
+++ b/src/content/3.9/Algebras for Monads.tex
@@ -382,7 +382,7 @@ get &\Colon a \to s
 ``small'' part of it.) In terms of this pair, we have:
 \[coalg_s\ a = Store\ (set\ a)\ (get\ a)\]
 Here, $a$ is a value of type $a$. Notice that partially
-applied $\Set$ is a function $s \to a$.
+applied \code{set} is a function $s \to a$.
 
 We also know that $Store\ s$ is a comonad:
 


### PR DESCRIPTION
The chapters on [Comonads](https://bartoszmilewski.com/2017/01/02/comonads/) and [Algebras for Monads](https://bartoszmilewski.com/2017/03/14/algebras-for-monads/) each feature a Haskell function named `set`, but this is being typeset as if it were the category **Set** in two places (as of #56).