### PR TITLE
Fix typesetting issues in Chapters 25 and 26.

### DIFF
--- a/src/content/3.10/Ends and Coends.tex
+++ b/src/content/3.10/Ends and Coends.tex
@@ -117,7 +117,7 @@ $\Set$-valued profunctors), and the sides are a family of
 functions mapping the apex to the sets in the base. You may think of
 this family as one polymorphic function --- a function that's
 polymorphic in its return type:
-\[\alpha \Colon \forall a\ .\ apex -> p\ a\ a\]
+\[\alpha \Colon \forall a\ .\ apex \to p\ a\ a\]
 Unlike in cones, within a wedge we don't have any functions that would
 connect vertices of the base. However, as we've seen earlier, given any
 morphism $f \Colon a \to b$ in $\cat{C}$, we can connect both

--- a/src/content/3.9/Algebras for Monads.tex
+++ b/src/content/3.9/Algebras for Monads.tex
@@ -119,7 +119,7 @@ adjunctions that the left adjoint to a forgetful functor is called a
 free functor.
 
 The left adjoint to $U^T$ is called $F^T$. It maps an object
-$A$ in $\cat{C}$ to a free algebra in $\cat{C}^T$. The carrier
+$a$ in $\cat{C}$ to a free algebra in $\cat{C}^T$. The carrier
 of this free algebra is $T\ a$. Its evaluator is a morphism from
 $T\ (T\ a)$ back to $T\ a$. Since $T$ is a monad,
 we can use the monadic $\mu_a$ (\code{join} in Haskell) as the
@@ -247,8 +247,8 @@ same as the $\mu$ of the original monad $T$.
 
 We've seen the Kleisli category before. It's a category constructed from
 another category $\cat{C}$ and a monad $T$. We'll call this
-category $\cat{C}^T$. The objects in the Kleisli category
-$\cat{C}^T$ are the objects of $\cat{C}$, but the morphisms
+category $\cat{C}_T$. The objects in the Kleisli category
+$\cat{C}_T$ are the objects of $\cat{C}$, but the morphisms
 are different. A morphism $f_{\cat{K}}$ from $a$ to $b$ in
 the Kleisli category corresponds to a morphism $f$ from
 $a$ to $T\ b$ in the original category. We call this
@@ -292,7 +292,7 @@ We can also define a functor $G$ from $\cat{C}_T$
 back to $\cat{C}$. It takes an object $a$ from the Kleisli
 category and maps it to an object $T\ a$ in $\cat{C}$. Its action 
 on a morphism $f_{\cat{K}}$ corresponding to a Kleisli arrow:
-\[f \Colon a -> T\ b\]
+\[f \Colon a \to T\ b\]
 is a morphism in $\cat{C}$:
 \[T\ a \to T\ b\]
 given by first lifting $f$ and then applying $\mu$:


### PR DESCRIPTION
The chapters on [Algebras for Monads](https://bartoszmilewski.com/2017/03/14/algebras-for-monads/) and [Ends and Coends](https://bartoszmilewski.com/2017/03/29/ends-and-coends/) have a few typesetting issues (which were introduced in #66):

- An instance where "object _a_" is written as "object _A_"
- Two instances where the Kleisli category **C**<sub>_T_</sub> is written as **C**<sup>_T_</sup>
- Two instances where → is written as `->`

-----
By the way, so far I've only been making corrections when the TeX differs from the original text, but I notice there are a couple of spelling errors as well as another typesetting error (µ<sub>_T_ _b_</sub> instead of µ<sub>_Tb_</sub>) which are also present in the original text. Should I fix these as well, or somehow make note of them separately?