### PR TITLE
typo on notation of the horizontal composition

### DIFF
--- a/src/content/1.10/natural-transformations.tex
+++ b/src/content/1.10/natural-transformations.tex
@@ -603,7 +603,7 @@ straightforward, provided you have enough patience.
 
 We call this natural transformation the \newterm{horizontal composition} of
 $\alpha$ and $\beta$:
-\[\beta \circ \alpha \Colon G \circ F \to G' \circ F'\]
+\[\beta \cdot \alpha \Colon G \circ F \to G' \circ F'\]
 Again, following Mac Lane I use the small circle for horizontal
 composition, although you may also encounter star in its place.
 


### PR DESCRIPTION
the notation of horizontal natural transformation compose should be dot `⋅`, not circle `∘`