### PR TITLE
Fix OneOfThree Scala example

### DIFF
--- a/src/content/1.6/code/scala/snippet22.scala
+++ b/src/content/1.6/code/scala/snippet22.scala
@@ -1,4 +1,4 @@
-sealed trait OneOfThree[A, B, C]
+sealed trait OneOfThree[+A, +B, +C]
 final case class Sinistral[A](v: A) extends OneOfThree[A, Nothing, Nothing]
 final case class Medial[B](v: B) extends OneOfThree[Nothing, B, Nothing]
 final case class Dextral[C](v: C) extends OneOfThree[Nothing, Nothing, C]


### PR DESCRIPTION
This fixes the issue https://github.com/hmemcpy/milewski-ctfp-pdf/issues/179 by making the type parameters in the OneOfThree Scala example covariant.

(Is this all that needs to be done to fix this?)