### PR TITLE
Remove unnecessary brackets

### DIFF
--- a/src/content/1.8/code/haskell/snippet10.hs
+++ b/src/content/1.8/code/haskell/snippet10.hs
@@ -1,3 +1,3 @@
 instance (Bifunctor bf, Functor fu, Functor gu) =>
   Bifunctor (BiComp bf fu gu) where
-    bimap f1 f2 (BiComp x) = BiComp ((bimap (fmap f1) (fmap f2)) x)
+    bimap f1 f2 (BiComp x) = BiComp (bimap (fmap f1) (fmap f2) x)


### PR DESCRIPTION
In the instance declaration of `BiComp`.