### PR TITLE
Fixed little haskell snippet

### DIFF
--- a/src/content/1.8/code/haskell/snippet13.hs
+++ b/src/content/1.8/code/haskell/snippet13.hs
@@ -1,2 +1,2 @@
-bimap :: (fu a -> fu a') -> (gu b -> gu b')
+bimap :: (a -> a') -> (b -> b')
   -> bf (fu a) (gu b) -> bf (fu a') (gu b')


### PR DESCRIPTION
I'm not sure if this is correct, but it should be. Some lines before that it is said that f1 and f2 are of types a -> a' and b -> b'
so it's only logical in the definition of bimap their corresponding types to be the same.