### PR TITLE
Refactor: remove duplication in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -47,17 +47,17 @@ version.tex:
 	git describe --tags --always --long | tr -d '\n' >> version.tex
 	/bin/echo -n '}' >> version.tex
 
-copy:
-	echo 'Creating output directory: $(GIT_VER)'
-	mkdir -p ../out/$(GIT_VER)
-	mv ctfp-reader.pdf ../out/$(GIT_VER)/category-theory-for-programmers.pdf
-	mv ctfp-print.pdf ../out/$(GIT_VER)/category-theory-for-programmers-print.pdf
+copy: suffix = ''
+copy: copy-task
 
-copy-scala: #remove this awful duplication ASAP
+copy-scala: suffix = '-scala'
+copy-scala: copy-task
+
+copy-task:
 	echo 'Creating output directory: $(GIT_VER)'
 	mkdir -p ../out/$(GIT_VER)
-	mv ctfp-reader-scala.pdf ../out/$(GIT_VER)/category-theory-for-programmers-scala.pdf
-	mv ctfp-print-scala.pdf ../out/$(GIT_VER)/category-theory-for-programmers-scala-print.pdf
+	mv ctfp-reader$(suffix).pdf ../out/$(GIT_VER)/category-theory-for-programmers$(suffix).pdf
+	mv ctfp-print$(suffix).pdf ../out/$(GIT_VER)/category-theory-for-programmers$(suffix)-print.pdf
 
 clean:
 	rm -f *~ *.aux {ctfp-*}.{out,log,pdf,dvi,fls,fdb_latexmk,aux,brf,bbl,idx,ilg,ind,toc,sed}


### PR DESCRIPTION
Hi @hmemcpy !

I'm preparing the files for Kotlin edition and I saw this comment in `Makefile`:

```
#remove this awful duplication ASAP
```

This **super tiny** _pull request_ is making a proposal for removing that duplication.

The variable definition is not necessary for the `copy` target so this line could be removed:

```
copy: suffix = ''
```

However, I prefer to make things explicit. 

You'll see something like:

```
mv ctfp-reader''.pdf ../out/v1.3.0-2-gf7db7ca/category-theory-for-programmers''.pdf
mv ctfp-print''.pdf ../out/v1.3.0-2-gf7db7ca/category-theory-for-programmers''-print.pdf
```

or:

```
mv ctfp-reader'-scala'.pdf ../out/v1.3.0-2-gf7db7ca/category-theory-for-programmers'-scala'.pdf
mv ctfp-print'-scala'.pdf ../out/v1.3.0-2-gf7db7ca/category-theory-for-programmers'-scala'-print.pdf
```

And the directory content will be the expected one:

```
$ tree out/v1.3.0-2-gf7db7ca/
out/v1.3.0-2-gf7db7ca/
├── category-theory-for-programmers.pdf
├── category-theory-for-programmers-print.pdf
├── category-theory-for-programmers-scala.pdf
└── category-theory-for-programmers-scala-print.pdf
```