### PR TITLE
Tupeling return type in prodToSum method in section 6.4

### DIFF
--- a/src/content/1.6/code/scala/snippet34.scala
+++ b/src/content/1.6/code/scala/snippet34.scala
@@ -1,6 +1,6 @@
 def prodToSum[A, B, C]: ((A, Either[B, C])) => Either[(A, B), (A, C)] = {
   case (x, e) => e match {
-    case Left(y) => Left(x, y)
-    case Right(z) => Right(x, z)
+    case Left(y) => Left((x, y))
+    case Right(z) => Right((x, z))
   }
 }


### PR DESCRIPTION
Explicitly Tupling return in `prodToSum` method in Chapter 6

Mostly because it will produce these warnings if "-Xlint:adapted-args" is turned on, and it makes more clear that `sumToProd` is the inverse function as it does tuple the pair in the pattern match

```
[REDACTED]/src/main/scala/Main.scala:5:30: adapted the argument list to the expected 2-tuple: add additional parens instead
[warn]         signature: Left.apply[A, B](value: A): scala.util.Left[A,B]
[warn]   given arguments: x, y
[warn]  after adaptation: Left((x, y): (A, B))
[warn]         case Left(y)  => Left(x, y)
[warn]                              ^
[warn] [REDACTED]/src/main/scala/Main.scala:6:31: adapted the argument list to the expected 2-tuple: add additional parens instead
[warn]         signature: Right.apply[A, B](value: B): scala.util.Right[A,B]
[warn]   given arguments: x, z
[warn]  after adaptation: Right((x, z): (A, C))
[warn]         case Right(z) => Right(x, z)
[warn]                               ^
[warn] two warnings found
[info] Done compiling.
```

Should I wait for this to get merged in before updating the `errata` file?