### PR TITLE
fix to the coend definition

### DIFF
--- a/src/content/3.10/code/scala/snippet14.scala
+++ b/src/content/3.10/code/scala/snippet14.scala
@@ -1,3 +1,2 @@
-trait Coend[P[_, _]] {
-  def paa[A]: P[A, A]
-}
+sealed trait Coend[P[_, _]]
+final case class DiagP[A](p: P[A, A]) extends Coend[P]


### PR DESCRIPTION
I think the previous code for `Coend` was incorrect. The previous code was in no way different from the code for `trait PolyFunction1`, i.e. for `End`. The existential quantifier is encoded in Scala as a case class with an extra type parameter. The universal quantifier is encoded as a trait with a method having a type parameter.