### PR TITLE
Fix OCaml and ReasonML ribbon colors

### DIFF
--- a/src/cover/ribbon-ocaml.tex
+++ b/src/cover/ribbon-ocaml.tex
@@ -17,7 +17,7 @@
     \coordinate (B) at ($ (current page.south east) + (0,\stripskip) $);% <-- changed coordinate from 'north' to south' and sign for \stripskip
     \coordinate (B') at ($(B) + (0,\stripwidth) $);% <-- changed sign for \stripskip 
 
-    \fill [RedOrange!20] (A) -- (A') -- (B') -- (B) -- cycle;
+    \fill [BurntOrange!20] (A) -- (A') -- (B') -- (B) -- cycle;
 
     \coordinate (tempA) at ($(A)!.5!(A')$);
     \coordinate (tempB) at ($(B)!.5!(B')$);

--- a/src/cover/ribbon-reason.tex
+++ b/src/cover/ribbon-reason.tex
@@ -3,7 +3,7 @@
 \newcommand{\stripskip}{4}
 \newcommand{\stripwidth}{3}
 
-\definecolor{RedOrange}{rgb}{0.8, 0.33, 0.0}
+\definecolor{RedOrange}{rgb}{0.86, 0.30, 0.25}
 
 \begin{tikzpicture}[
     overlay,


### PR DESCRIPTION
It was probably not obvious, since I reused the OCaml color in Reason, but: Now that I changed it to the actual ReasonML color, I found out that I accidentally overwrote the `BurntOrange` color for OCaml.