### PR TITLE
Replace template<class> with template<typename>

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To build the Scala edition, type:
 $ make scala
 ```
 
-Upon successful compilation, the files will be placed in the `out` directory next to `src`. 
+Upon successful compilation, the files will be placed in the `out` directory next to `src`.
 
 The file `preamble.tex` contains all the configuration and style declarations.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -33,7 +33,7 @@ OCAMLPDF:=$(OCAMLTEXFILES:.tex=.pdf)
 # ReasonML PDF file to make
 REASONPDF:=$(REASONTEXFILES:.tex=.pdf)
 
-# Other PDF files for the CTFP book 
+# Other PDF files for the CTFP book
 TOPPDFFILES:=$(TOPTEXFILES:.tex=.pdf)
 
 # Configuration files
@@ -81,5 +81,5 @@ clean:
 	if which latexmk > /dev/null 2>&1 ; then latexmk -CA; fi
 	rm -rf ../out
 
-clean-minted: 
+clean-minted:
 	rm -rf _minted-*

--- a/src/content/0.0/preface.tex
+++ b/src/content/0.0/preface.tex
@@ -13,7 +13,7 @@ Feynman, but I will try my best. I'm starting by publishing this preface
 --- which is supposed to motivate the reader to learn category theory
 --- in hopes of starting a discussion and soliciting feedback.\footnote{
 You may also watch me teach this material to a live audience, at
-\href{https://goo.gl/GT2UWU}{https://goo.gl/GT2UWU} (or search 
+\href{https://goo.gl/GT2UWU}{https://goo.gl/GT2UWU} (or search
 ``bartosz milewski category theory'' on YouTube.)}
 \end{quote}
 

--- a/src/content/1.1/category-the-essence-of-composition.tex
+++ b/src/content/1.1/category-the-essence-of-composition.tex
@@ -131,7 +131,7 @@ implementation is the same for every type, which means this function is
 universally polymorphic. In C++ we could define it as a template:
 
 \begin{snip}{cpp}
-template<class T> T id(T x) { return x; }
+template<typename T> T id(T x) { return x; }
 \end{snip}
 Of course, in C++ nothing is that simple, because you have to take into
 account not only what you're passing but also how (that is, by value, by

--- a/src/content/1.10/natural-transformations.tex
+++ b/src/content/1.10/natural-transformations.tex
@@ -162,7 +162,7 @@ Keep in mind that it's really a family of functions parameterized by
 syntax. A similar construct in C++ would be slightly more verbose:
 
 \begin{snip}{cpp}
-template<class A> G<A> alpha(F<A>);
+template<typename A> G<A> alpha(F<A>);
 \end{snip}
 There is a more profound difference between Haskell's polymorphic
 functions and C++ generic functions, and it's reflected in the way these

--- a/src/content/1.2/types-and-functions.tex
+++ b/src/content/1.2/types-and-functions.tex
@@ -394,7 +394,7 @@ to unit type? Of course we'll call it \code{unit}:
 In C++ you would write this function as:
 
 \begin{snip}{cpp}
-template<class T>
+template<typename T>
 void unit(T) {}
 \end{snip}
 Next in the typology of types is a two-element set. In C++ it's called

--- a/src/content/1.2/types-and-functions.tex
+++ b/src/content/1.2/types-and-functions.tex
@@ -408,7 +408,7 @@ can be defined as follows:
 to define a Boolean type in C++ as an enumeration:
 
 \begin{snip}{cpp}
-enum bool { 
+enum bool {
     true,
     false
 };
@@ -468,7 +468,7 @@ std::getchar()
 \end{minted}
   \item
 \begin{minted}{cpp}
-bool f() { 
+bool f() {
     std::cout << "Hello!" << std::endl;
     return true;
 }

--- a/src/content/1.3/categories-great-and-small.tex
+++ b/src/content/1.3/categories-great-and-small.tex
@@ -180,13 +180,13 @@ The closest one can get to declaring a monoid in C++ would be to use the
 C++20 standard's concept feature.
 
 \begin{snip}{cpp}
-template<class T>
+template<typename T>
 struct mempty;
 
-template<class T>
+template<typename T>
 T mappend(T, T) = delete;
 
-template<class M>
+template<typename M>
 concept Monoid = requires (M m) {
     { mempty<M>::value() } -> std::same_as<M>;
     { mappend(m, m) } -> std::same_as<M>;

--- a/src/content/1.4/kleisli-categories.tex
+++ b/src/content/1.4/kleisli-categories.tex
@@ -120,7 +120,7 @@ encapsulates a pair whose first component is a value of arbitrary type
 \code{A} and the second component is a string:
 
 \begin{snip}{cpp}
-template<class A>
+template<typename A>
 using Writer = pair<A, string>;
 \end{snip}
 Here are the embellished functions:
@@ -226,7 +226,7 @@ embellished functions that are composable according to our rules, and
 return a third embellished function:
 
 \begin{snip}{cpp}
-template<class A, class B, class C>
+template<typename A, typename B, typename C>
 function<Writer<C>(A)> compose(function<Writer<B>(A)> m1,
                                function<Writer<C>(B)> m2)
 {
@@ -281,7 +281,7 @@ should pass its argument without change, and only contribute an empty
 string to the log:
 
 \begin{snip}{cpp}
-template<class A>
+template<typename A>
 Writer<A> identity(A x) {
     return make_pair(x, "");
 }
@@ -410,7 +410,7 @@ can, however, be represented by a function that returns an embellished
 type \code{optional}:
 
 \begin{snip}{cpp}
-template<class A>
+template<typename A>
 class optional {
     bool _isValid;
     A _value;

--- a/src/content/1.4/kleisli-categories.tex
+++ b/src/content/1.4/kleisli-categories.tex
@@ -281,7 +281,8 @@ should pass its argument without change, and only contribute an empty
 string to the log:
 
 \begin{snip}{cpp}
-template<class A> Writer<A> identity(A x) {
+template<class A>
+Writer<A> identity(A x) {
     return make_pair(x, "");
 }
 \end{snip}
@@ -409,7 +410,8 @@ can, however, be represented by a function that returns an embellished
 type \code{optional}:
 
 \begin{snip}{cpp}
-template<class A> class optional {
+template<class A>
+class optional {
     bool _isValid;
     A _value;
 public:

--- a/src/content/1.4/kleisli-categories.tex
+++ b/src/content/1.4/kleisli-categories.tex
@@ -98,7 +98,7 @@ vector<string> words(string s) {
     for (auto i = begin(s); i != end(s); ++i)
     {
         if (isspace(*i))
-            result.push_back(""); 
+            result.push_back("");
         else
             result.back() += *i;
     }
@@ -130,10 +130,10 @@ Writer<string> toUpper(string s) {
     string result;
     int (*toupperp)(int) = &toupper;
     transform(begin(s), end(s), back_inserter(result), toupperp);
-    return make_pair(result, "toUpper "); 
+    return make_pair(result, "toUpper ");
 }
 
-Writer<vector<string>> toWords(string s) { 
+Writer<vector<string>> toWords(string s) {
     return make_pair(words(s), "toWords ");
 }
 \end{snip}
@@ -233,7 +233,7 @@ function<Writer<C>(A)> compose(function<Writer<B>(A)> m1,
     return [m1, m2](A x) {
         auto p1 = m1(x);
         auto p2 = m2(p1.first);
-        return make_pair(p2.first, p1.second + p2.second); 
+        return make_pair(p2.first, p1.second + p2.second);
     };
 }
 \end{snip}
@@ -241,7 +241,7 @@ Now we can go back to our earlier example and implement the composition
 of \code{toUpper} and \code{toWords} using this new template:
 
 \begin{snip}{cpp}
-Writer<vector<string>> process(string s) { 
+Writer<vector<string>> process(string s) {
     return compose<string, string, vector<string>>(toUpper, toWords)(s);
 }
 \end{snip}
@@ -251,8 +251,8 @@ C++14-compliant compiler that supports generalized lambda functions with
 return type deduction (credit for this code goes to Eric Niebler):
 
 \begin{snip}{cpp}
-auto const compose = [](auto m1, auto m2) { 
-    return [m1, m2](auto x) { 
+auto const compose = [](auto m1, auto m2) {
+    return [m1, m2](auto x) {
         auto p1 = m1(x);
         auto p2 = m2(p1.first);
         return make_pair(p2.first, p1.second + p2.second);
@@ -412,7 +412,7 @@ type \code{optional}:
 template<class A> class optional {
     bool _isValid;
     A _value;
-public: 
+public:
     optional()    : _isValid(false) {}
     optional(A v) : _isValid(true), _value(v) {}
     bool isValid() const { return _isValid; }
@@ -424,7 +424,7 @@ For example, here's the implementation of the embellished function
 
 \begin{snip}{cpp}
 optional<double> safe_root(double x) {
-    if (x >= 0) return optional<double>{sqrt(x)}; 
+    if (x >= 0) return optional<double>{sqrt(x)};
     else return optional<double>{};
 }
 \end{snip}

--- a/src/content/1.5/products-and-coproducts.tex
+++ b/src/content/1.5/products-and-coproducts.tex
@@ -244,7 +244,7 @@ wildcards:
 In C++, we would use template functions, for instance:
 
 \begin{snip}{cpp}
-template<class A, class B>
+template<typename A, typename B>
 A fst(pair<A, B> const & p) {
     return p.first;
 }

--- a/src/content/1.5/products-and-coproducts.tex
+++ b/src/content/1.5/products-and-coproducts.tex
@@ -445,7 +445,7 @@ union. For instance, a tagged union of an \code{int} and a
 \code{char const *} could be implemented as:
 
 \begin{snip}{cpp}
-struct Contact { 
+struct Contact {
     enum { isPhone, isEmail } tag;
     union { int phoneNum; char const * emailAddr; };
 };
@@ -455,7 +455,7 @@ functions. For instance, here's the first injection as a function
 \code{PhoneNum}:
 
 \begin{snip}{cpp}
-Contact PhoneNum(int n) { 
+Contact PhoneNum(int n) {
     Contact c;
     c.tag = isPhone;
     c.phoneNum = n;
@@ -623,7 +623,7 @@ int m(Either const & e);
   Still continuing: What about these injections?
 
 \begin{snip}{cpp}
-int i(int n) { 
+int i(int n) {
     if (n < 0) return n;
     return n + 2;
 }

--- a/src/content/1.5/products-and-coproducts.tex
+++ b/src/content/1.5/products-and-coproducts.tex
@@ -244,8 +244,8 @@ wildcards:
 In C++, we would use template functions, for instance:
 
 \begin{snip}{cpp}
-template<class A, class B> A
-fst(pair<A, B> const & p) {
+template<class A, class B>
+A fst(pair<A, B> const & p) {
     return p.first;
 }
 \end{snip}

--- a/src/content/1.6/simple-algebraic-data-types.tex
+++ b/src/content/1.6/simple-algebraic-data-types.tex
@@ -253,7 +253,7 @@ can be translated to C++ using the null pointer trick to implement the
 empty list:
 
 \begin{snip}{cpp}
-template<class A>
+template<typename A>
 class List {
     Node<A> * _head;
 public:

--- a/src/content/1.6/simple-algebraic-data-types.tex
+++ b/src/content/1.6/simple-algebraic-data-types.tex
@@ -254,7 +254,7 @@ empty list:
 
 \begin{snip}{cpp}
 template<class A>
-class List { 
+class List {
     Node<A> * _head;
 public:
     List() : _head(nullptr) {} // Nil
@@ -472,7 +472,7 @@ talk about function types.
   Here's a sum type defined in Haskell:
 
 \begin{snip}{haskell}
-data Shape = Circle Float 
+data Shape = Circle Float
            | Rect Float Float
 \end{snip}
   When we want to define a function like \code{area} that acts on a

--- a/src/content/1.7/functors.tex
+++ b/src/content/1.7/functors.tex
@@ -206,6 +206,8 @@ First the \code{Nothing} case:
   fmap g Nothing
 = { definition of fmap }
   fmap g (fmap f Nothing)
+= { definition of composition }
+  (fmap g . fmap f) Nothing
 \end{snip}
 And then the \code{Just} case:
 

--- a/src/content/1.7/functors.tex
+++ b/src/content/1.7/functors.tex
@@ -261,7 +261,7 @@ argument may be passed, with copy semantics, and with the resource
 management issues characteristic of C++):
 
 \begin{snip}{cpp}
-template<class T>
+template<typename T>
 class optional {
     bool _isValid; // the tag
     T _v;
@@ -277,7 +277,7 @@ mapping of types. It maps any type \code{T} to a new type
 functions:
 
 \begin{snip}{cpp}
-template<class A, class B>
+template<typename A, typename B>
 std::function<optional<B>(optional<A>)>
 fmap(std::function<B(A)> f) {
     return [f](optional<A> opt) {
@@ -292,7 +292,7 @@ This is a higher order function, taking a function as an argument and
 returning a function. Here's the uncurried version of it:
 
 \begin{snip}{cpp}
-template<class A, class B>
+template<typename A, typename B>
 optional<B> fmap(std::function<B(A)> f, optional<A> opt) {
     if (!opt.isValid())
         return optional<B>{};
@@ -375,7 +375,7 @@ parameterize \code{fmap} with a \newterm{template template parameter}
 \code{F}. This is the syntax for it:
 
 \begin{snip}{cpp}
-template<template<class> F, class A, class B>
+template<template<typename> F, typename A, typename B>
 F<B> fmap(std::function<B(A)>, F<A>);
 \end{snip}
 We would like to be able to specialize this template for different
@@ -383,14 +383,14 @@ functors. Unfortunately, there is a prohibition against partial
 specialization of template functions in C++. You can't write:
 
 \begin{snip}{cpp}
-template<class A, class B>
+template<typename A, typename B>
 optional<B> fmap<optional>(std::function<B(A)> f, optional<A> opt)
 \end{snip}
 Instead, we have to fall back on function overloading, which brings us
 back to the original definition of the uncurried \code{fmap}:
 
 \begin{snip}{cpp}
-template<class A, class B>
+template<typename A, typename B>
 optional<B> fmap(std::function<B(A)> f, optional<A> opt) {
     if (!opt.isValid())
         return optional<B>{};
@@ -451,7 +451,7 @@ container. The implementation of \code{fmap} for \code{std::vector}
 is just a thin encapsulation of \code{std::transform}:
 
 \begin{snip}{cpp}
-template<class A, class B>
+template<typename A, typename B>
 std::vector<B> fmap(std::function<B(A)> f, std::vector<A> v) {
     std::vector<B> w;
     std::transform( std::begin(v)
@@ -606,7 +606,7 @@ those words!), where there is a stronger distinction between type
 arguments --- which are compile-time --- and values, which are run-time:
 
 \begin{snip}{cpp}
-template<class C, class A>
+template<typename C, typename A>
 struct Const {
     Const(C v) : _v(v) {}
     C _v;
@@ -617,7 +617,7 @@ argument and essentially re-casts the \code{Const} argument without
 changing its value:
 
 \begin{snip}{cpp}
-template<class C, class A, class B>
+template<typename C, typename A, typename B>
 Const<C, B> fmap(std::function<B(A)> f, Const<C, A> c) {
     return Const<C, B>{c._v};
 }

--- a/src/content/1.7/functors.tex
+++ b/src/content/1.7/functors.tex
@@ -262,7 +262,7 @@ management issues characteristic of C++):
 
 \begin{snip}{cpp}
 template<class T>
-class optional { 
+class optional {
     bool _isValid; // the tag
     T _v;
 public:
@@ -279,11 +279,11 @@ functions:
 \begin{snip}{cpp}
 template<class A, class B>
 std::function<optional<B>(optional<A>)>
-fmap(std::function<B(A)> f) { 
-    return [f](optional<A> opt) { 
-        if (!opt.isValid()) 
+fmap(std::function<B(A)> f) {
+    return [f](optional<A> opt) {
+        if (!opt.isValid())
             return optional<B>{};
-        else 
+        else
             return optional<B>{ f(opt.val()) };
     };
 }
@@ -293,10 +293,10 @@ returning a function. Here's the uncurried version of it:
 
 \begin{snip}{cpp}
 template<class A, class B>
-optional<B> fmap(std::function<B(A)> f, optional<A> opt) { 
+optional<B> fmap(std::function<B(A)> f, optional<A> opt) {
     if (!opt.isValid())
         return optional<B>{};
-    else 
+    else
         return optional<B>{ f(opt.val()) };
 }
 \end{snip}
@@ -391,9 +391,9 @@ back to the original definition of the uncurried \code{fmap}:
 
 \begin{snip}{cpp}
 template<class A, class B>
-optional<B> fmap(std::function<B(A)> f, optional<A> opt) { 
-    if (!opt.isValid()) 
-        return optional<B>{}; 
+optional<B> fmap(std::function<B(A)> f, optional<A> opt) {
+    if (!opt.isValid())
+        return optional<B>{};
     else
         return optional<B>{ f(opt.val()) };
 }
@@ -457,7 +457,7 @@ std::vector<B> fmap(std::function<B(A)> f, std::vector<A> v) {
     std::transform( std::begin(v)
                   , std::end(v)
                   , std::back_inserter(w)
-                  , f); 
+                  , f);
     return w;
 }
 \end{snip}
@@ -607,7 +607,7 @@ arguments --- which are compile-time --- and values, which are run-time:
 
 \begin{snip}{cpp}
 template<class C, class A>
-struct Const { 
+struct Const {
     Const(C v) : _v(v) {}
     C _v;
 };

--- a/src/content/1.8/functoriality.tex
+++ b/src/content/1.8/functoriality.tex
@@ -305,7 +305,7 @@ support dynamic casting, so we'll make the destructor virtual (which is
 a good idea in any case):
 
 \begin{snip}{cpp}
-template<class T>
+template<typename T>
 struct Tree {
     virtual ~Tree() {};
 };
@@ -313,7 +313,7 @@ struct Tree {
 The \code{Leaf} is just an \code{Identity} functor in disguise:
 
 \begin{snip}{cpp}
-template<class T>
+template<typename T>
 struct Leaf : public Tree<T> {
     T _label;
     Leaf(T l) : _label(l) {}
@@ -322,7 +322,7 @@ struct Leaf : public Tree<T> {
 The \code{Node} is a product type:
 
 \begin{snip}{cpp}
-template<class T>
+template<typename T>
 struct Node : public Tree<T> {
     Tree<T> * _left;
     Tree<T> * _right;
@@ -338,7 +338,7 @@ analyzing code in these terms, but it's a good exercise in categorical
 thinking.
 
 \begin{snip}{cpp}
-template<class A, class B>
+template<typename A, typename B>
 Tree<B> * fmap(std::function<B(A)> f, Tree<A> * t) {
     Leaf<A> * pl = dynamic_cast <Leaf<A>*>(t);
     if (pl)

--- a/src/content/1.8/functoriality.tex
+++ b/src/content/1.8/functoriality.tex
@@ -306,7 +306,7 @@ a good idea in any case):
 
 \begin{snip}{cpp}
 template<class T>
-struct Tree { 
+struct Tree {
     virtual ~Tree() {};
 };
 \end{snip}
@@ -345,7 +345,7 @@ Tree<B> * fmap(std::function<B(A)> f, Tree<A> * t) {
         return new Leaf<B>(f (pl->_label));
     Node<A> * pn = dynamic_cast<Node<A>*>(t);
     if (pn)
-        return new Node<B>( fmap<A>(f, pn->_left) 
+        return new Node<B>( fmap<A>(f, pn->_left)
                           , fmap<A>(f, pn->_right));
     return nullptr;
 }

--- a/src/content/2.2/limits-and-colimits.tex
+++ b/src/content/2.2/limits-and-colimits.tex
@@ -39,7 +39,7 @@ to define our patterns.
 \centering
 \includegraphics[width=0.35\textwidth]{images/two.jpg}
 \end{figure}
-  
+
 \noindent
 But let's continue. The next step in the definition of a product is the
 selection of the candidate object $c$. Here again, we could
@@ -520,7 +520,7 @@ It will also come up with a set of constraints resulting from the rules
 of function application:
 
 \begin{snip}{haskell}
-t0 = t1 -> t2 -- because f is applied to x 
+t0 = t1 -> t2 -- because f is applied to x
 t0 = t2 -> t3 -- because f is applied to (f x)
 \end{snip}
 These constraints have to be unified by finding a set of types (or type
@@ -528,7 +528,7 @@ variables) that, when substituted for the unknown types in both
 expressions, produce the same type. One such substitution is:
 
 \begin{snip}{haskell}
-t1 = t2 = t3 = Int 
+t1 = t2 = t3 = Int
 twice :: (Int -> Int) -> Int -> Int
 \end{snip}
 but, obviously, it's not the most general one. The most general

--- a/src/content/2.3/free-monoids.tex
+++ b/src/content/2.3/free-monoids.tex
@@ -1,7 +1,7 @@
 % !TEX root = ../../ctfp-print.tex
 
 \lettrine[lhang=0.17]{M}{onoids are an important} concept in both category
-theory and in programming. Categories correspond to strongly typed languages, 
+theory and in programming. Categories correspond to strongly typed languages,
 monoids to untyped languages. That's because in a monoid you can compose any
 two arrows, just as in an untyped language you can compose any two functions
 (of course, you may end up with a runtime error when you execute your

--- a/src/content/2.4/representable-functors.tex
+++ b/src/content/2.4/representable-functors.tex
@@ -202,7 +202,7 @@ It must respect naturality conditions, and it must be the inverse of \code{alpha
 alpha . beta = id = beta . alpha
 \end{snip}
 We will see later that a natural transformation from $\cat{C}(a, -)$
-to any $\Set$-valued functor always exists as long as $F a$ is 
+to any $\Set$-valued functor always exists as long as $F a$ is
 non-empty (Yoneda's lemma) but it is not necessarily invertible.
 
 Let me give you an example in Haskell with the list functor and

--- a/src/content/2.5/the-yoneda-lemma.tex
+++ b/src/content/2.5/the-yoneda-lemma.tex
@@ -103,7 +103,7 @@ We have just proven the Yoneda lemma:
 
 \begin{quote}
 There is a one-to-one correspondence between natural transformations
-from $\cat{C}(a, -)$ to $F$ and elements of $F a$. 
+from $\cat{C}(a, -)$ to $F$ and elements of $F a$.
 \end{quote}
 in other words,
 \[\cat{Nat}(\cat{C}(a, -), F) \cong F a\]

--- a/src/content/3.10/ends-and-coends.tex
+++ b/src/content/3.10/ends-and-coends.tex
@@ -405,7 +405,7 @@ exponential:
 \[\int_z \Set(\cat{C}(z, a), c^{(F\ z)})\]
 We can ``perform the integration'' by using the Yoneda lemma to get:
 \[c^{(F\ a)}\]
-(Notice that we used the contravariant version of the Yoneda lemma, 
+(Notice that we used the contravariant version of the Yoneda lemma,
 since the functor $c^{(F z)}$ is contravariant in $z$.)
 This exponential object is isomorphic to the hom-set:
 \[\Set(F\ a, c)\]

--- a/src/content/3.14/lawvere-theories.tex
+++ b/src/content/3.14/lawvere-theories.tex
@@ -496,7 +496,7 @@ identified.
 \begin{tikzcd}
   & a^n \times \cat{L}(m, 1)
     \arrow[dl, "\langle f {,} \id \rangle"']
-    \arrow[dr, "\langle \id {,} f \rangle"] 
+    \arrow[dr, "\langle \id {,} f \rangle"]
     & \\
 a^m \times \cat{L}(m, 1)
   & \scalebox{2.5}[1]{\sim}
@@ -579,7 +579,7 @@ by lifting $0 \to n$ in two different ways.
 \begin{tikzcd}
   & a^n \times \cat{L}(0, 1)
     \arrow[dl, "\langle f {,} \id \rangle"']
-    \arrow[dr, "\langle \id {,} f \rangle"] 
+    \arrow[dr, "\langle \id {,} f \rangle"]
     & \\
 a^0 \times \cat{L}(0, 1)
   & \scalebox{2.5}[1]{\sim}

--- a/src/content/3.2/adjunctions.tex
+++ b/src/content/3.2/adjunctions.tex
@@ -156,18 +156,18 @@ diagrams commute:
   \begin{subfigure}
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
-    	L \arrow[rd, equal] \arrow[r, "L \circ \eta"] 
-          & L \circ R \circ L \arrow[d, "\epsilon \circ L"] \\
-    	    & L
+      L \arrow[rd, equal] \arrow[r, "L \circ \eta"]
+        & L \circ R \circ L \arrow[d, "\epsilon \circ L"] \\
+        & L
     \end{tikzcd}
   \end{subfigure}%
   \hspace{1cm}
   \begin{subfigure}
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
-      R \arrow[rd, equal] \arrow[r, "\eta \circ R"] 
-          & R \circ L \circ R \arrow[d, "R \circ \epsilon"] \\
-          & R
+      R \arrow[rd, equal] \arrow[r, "\eta \circ R"]
+        & R \circ L \circ R \arrow[d, "R \circ \epsilon"] \\
+        & R
     \end{tikzcd}
   \end{subfigure}
 \end{figure}
@@ -522,7 +522,7 @@ can be seen as an adjunction. Again, the trick is to concentrate on the
 statement:
 
 \begin{quote}
-For any other object $z$ with a morphism $g \Colon z\times{}a \to b$ 
+For any other object $z$ with a morphism $g \Colon z\times{}a \to b$
 there is a unique morphism $h \Colon z \to (a \Rightarrow b)$
 \end{quote}
 This statement establishes a mapping between hom-sets.

--- a/src/content/3.3/free-forgetful-adjunctions.tex
+++ b/src/content/3.3/free-forgetful-adjunctions.tex
@@ -50,7 +50,7 @@ universal construction we've discussed before.\footnote{See ch.13 on
   $m_2$ and $m_3$ than there are morphisms
   between them.}
 \end{figure}
-  
+
 \noindent
 In terms of hom-sets, we can write this adjunction as:
 \[\cat{Mon}(F x, m) \cong \Set(x, U m)\]

--- a/src/content/3.9/algebras-for-monads.tex
+++ b/src/content/3.9/algebras-for-monads.tex
@@ -52,7 +52,7 @@ $T$ in anticipation of what follows):
   \begin{subfigure}
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
-      a \arrow[rd, equal] \arrow[r, "\eta_a"] 
+      a \arrow[rd, equal] \arrow[r, "\eta_a"]
           & Ta \arrow[d, "alg"] \\
           & a
     \end{tikzcd}
@@ -196,7 +196,7 @@ counit satisfy triangular identities. These are:
   \begin{subfigure}
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
-      Ta \arrow[rd, equal] \arrow[r, "T \eta_a"] 
+      Ta \arrow[rd, equal] \arrow[r, "T \eta_a"]
           & T(Ta) \arrow[d, "\mu_a"] \\
           & Ta
     \end{tikzcd}
@@ -205,7 +205,7 @@ counit satisfy triangular identities. These are:
   \begin{subfigure}
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
-      a \arrow[rd, equal] \arrow[r, "\eta_a"] 
+      a \arrow[rd, equal] \arrow[r, "\eta_a"]
           & Ta \arrow[d, "f"] \\
           & a
     \end{tikzcd}
@@ -292,7 +292,7 @@ In Haskell we'd write it as:
 \src{snippet06}
 We can also define a functor $G$ from $\cat{C}_T$
 back to $\cat{C}$. It takes an object $a$ from the Kleisli
-category and maps it to an object $T\ a$ in $\cat{C}$. Its action 
+category and maps it to an object $T\ a$ in $\cat{C}$. Its action
 on a morphism $f_{\cat{K}}$ corresponding to a Kleisli arrow:
 \[f \Colon a \to T\ b\]
 is a morphism in $\cat{C}$:
@@ -329,7 +329,7 @@ with a comonad. They make the following diagrams commute:
   \begin{subfigure}
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
-      a \arrow[rd, equal] 
+      a \arrow[rd, equal]
           & Wa \arrow[l, "\epsilon_a"'] \\
           & a \arrow[u, "coa"']
     \end{tikzcd}

--- a/src/content/ocaml/colophon.tex
+++ b/src/content/ocaml/colophon.tex
@@ -1,2 +1,2 @@
-OCaml code translation was done by \urlref{https://github.com/ArulselvanMadhavan/ocaml-ctfp}{Arulselvan Madhavan} 
+OCaml code translation was done by \urlref{https://github.com/ArulselvanMadhavan/ocaml-ctfp}{Arulselvan Madhavan}
 and reviewed by \urlref{http://www.mseri.me}{Marcello Seri} and \urlref{https://github.com/XVilka}{Anton Kochkov}.

--- a/src/content/ocaml/editor-note.tex
+++ b/src/content/ocaml/editor-note.tex
@@ -8,17 +8,17 @@ other programming languages.
 
 I am thrilled to present this edition of the book, containing the original Haskell code, followed by
 its OCaml counterpart. The OCaml code snippets were generously provided by
-\urlref{https://github.com/ArulselvanMadhavan/ocaml-ctfp}{ocaml-ctfp} contributors, slightly 
+\urlref{https://github.com/ArulselvanMadhavan/ocaml-ctfp}{ocaml-ctfp} contributors, slightly
 modified to suit the format of this book.
 
 To support code snippets in multiple languages, I am using a \LaTeX{} macro to load the code snippets
-from external files. This allows easily extending the book with other languages, while leaving the 
+from external files. This allows easily extending the book with other languages, while leaving the
 original text intact. Which is why you should mentally append the words ``and OCaml'' whenever you see
 ``in Haskell'' in the text.
 
 The code is laid out in the following manner: the original Haskell code, followed by OCaml code.
 To distinguish between them, the code snippets are braced from the left with a vertical bar, in the primary
-color of the language's logo, \raisebox{-.2mm}{\includegraphics[height=.3cm]{fig/icons/haskell.png}}, 
+color of the language's logo, \raisebox{-.2mm}{\includegraphics[height=.3cm]{fig/icons/haskell.png}},
 and \raisebox{-.2mm}{\includegraphics[height=.3cm]{fig/icons/ocaml.png}} respectively, e.g.:
 
 \srcsnippet{content/1.1/code/haskell/snippet03.hs}{blue}{haskell}

--- a/src/content/reason/editor-note.tex
+++ b/src/content/reason/editor-note.tex
@@ -7,18 +7,18 @@ to improve the book, by fixing typos and errors, as well as translating the code
 other programming languages.
 
 I am thrilled to present this edition of the book, containing the original Haskell code, followed by
-its ReasonML counterpart. The ReasonML code snippets were converted from the OCaml snippets which were 
+its ReasonML counterpart. The ReasonML code snippets were converted from the OCaml snippets which were
 generously provided by \urlref{https://github.com/ArulselvanMadhavan/ocaml-ctfp}{ocaml-ctfp} contributors,
 and slightly modified to suit the format of this book.
 
 To support code snippets in multiple languages, I am using a \LaTeX{} macro to load the code snippets
-from external files. This allows easily extending the book with other languages, while leaving the 
+from external files. This allows easily extending the book with other languages, while leaving the
 original text intact. Which is why you should mentally append the words ``and ReasonML'' whenever you see
 ``in Haskell'' in the text.
 
 The code is laid out in the following manner: the original Haskell code, followed by ReasonML code.
 To distinguish between them, the code snippets are braced from the left with a vertical bar, in the primary
-color of the language's logo, \raisebox{-.2mm}{\includegraphics[height=.3cm]{fig/icons/haskell.png}}, 
+color of the language's logo, \raisebox{-.2mm}{\includegraphics[height=.3cm]{fig/icons/haskell.png}},
 and \raisebox{-.2mm}{\includegraphics[height=.3cm]{fig/icons/reason.png}} respectively, e.g.:
 
 \srcsnippet{content/1.1/code/haskell/snippet03.hs}{blue}{haskell}

--- a/src/content/scala/editor-note.tex
+++ b/src/content/scala/editor-note.tex
@@ -1,29 +1,29 @@
 % !TEX root = ctfp-print.tex
 
 \lettrine[lhang=0.17]{T}{his is the Scala edition} of \emph{Category Theory for Programmers}.
-It's been a tremendous success, making Bartosz Milewski's blog post series available as a nicely 
+It's been a tremendous success, making Bartosz Milewski's blog post series available as a nicely
 typeset \acronym{PDF}, as well as a hardcover book. There have been numerous contributions made
 to improve the book, by fixing typos and errors, as well as translating the code snippets into
 other programming languages.
 
 I am thrilled to present this edition of the book, containing the original Haskell code, followed by
-its Scala counterpart. The Scala code snippets were generously provided by 
-\urlref{https://github.com/typelevel/CT_from_Programmers.scala}{Typelevel} contributors, slightly 
+its Scala counterpart. The Scala code snippets were generously provided by
+\urlref{https://github.com/typelevel/CT_from_Programmers.scala}{Typelevel} contributors, slightly
 modified to suit the format of this book.
 
 To support code snippets in multiple languages, I am using a \LaTeX{} macro to load the code snippets
-from external files. This allows easily extending the book with other languages, while leaving the 
+from external files. This allows easily extending the book with other languages, while leaving the
 original text intact. Which is why you should mentally append the words ``and Scala'' whenever you see
 ``in Haskell'' in the text.
 
 The code is laid out in the following manner: the original Haskell code, followed by Scala code.
 To distinguish between them, the code snippets are braced from the left with a vertical bar, in the primary
-color of the language's logo, \raisebox{-.2mm}{\includegraphics[height=.3cm]{fig/icons/haskell.png}}, 
+color of the language's logo, \raisebox{-.2mm}{\includegraphics[height=.3cm]{fig/icons/haskell.png}},
 and \raisebox{-.2mm}{\includegraphics[height=.3cm]{fig/icons/scala.png}} respectively, e.g.:
 
 \srcsnippet{content/3.6/code/haskell/snippet03.hs}{blue}{haskell}
 \unskip
 \srcsnippet{content/3.6/code/scala/snippet03.scala}{red}{scala}
 \NoIndentAfterThis
-In addition, some Scala snippets make use of the 
+In addition, some Scala snippets make use of the
 \urlref{https://github.com/non/kind-projector}{Kind Projector} compiler plugin, to support nicer syntax for partially-applied types.

--- a/src/cover/cover-hardcover-ocaml.tex
+++ b/src/cover/cover-hardcover-ocaml.tex
@@ -6,14 +6,14 @@
     11pt,
     marklength=0pt,
   ]{bookcover}
-  
+
   \usepackage{fancybox}
   \usepackage{wrapfig}
   \usepackage[many]{tcolorbox}
   \usetikzlibrary{calc,positioning, shadings}
   \usepackage[T1]{fontenc}
   \usepackage{fontspec}
-  
+
   \setmainfont[
     Path=fonts/,
     Extension=.otf,
@@ -47,12 +47,12 @@
     \end{tcolorbox}
   }
   \input{\olpath/version}
-  
+
   \definecolor{BackgroundColor}{HTML}{f3f6ed}
   \definecolor{SpineBackColor}{HTML}{262626}
-  
+
   \begin{document}
-  
+
   \begin{bookcover}
     \bookcovercomponent{color}{bg whole}{color=BackgroundColor}
     \bookcovercomponent{color}{spine}{color=SpineBackColor}
@@ -71,7 +71,7 @@
       \vfil
       \vspace*{1cm}
     \end{center}}
-    
+
     \bookcovercomponent{center}{spine}{
       \rotatebox[origin=c]{-90}{\color{orange}
       \Huge\bfseries Category Theory for Programmers \hspace{2em} Bartosz Milewski}}
@@ -85,7 +85,7 @@
           \input{blurb}
           \vspace{.5cm}
         \end{minipage}
-        
+
         \begin{minipage}{.85\textwidth}
           \rule{\textwidth}{.5pt}
 

--- a/src/cover/cover-hardcover-reason.tex
+++ b/src/cover/cover-hardcover-reason.tex
@@ -6,14 +6,14 @@
     11pt,
     marklength=0pt,
   ]{bookcover}
-  
+
   \usepackage{fancybox}
   \usepackage{wrapfig}
   \usepackage[many]{tcolorbox}
   \usetikzlibrary{calc,positioning, shadings}
   \usepackage[T1]{fontenc}
   \usepackage{fontspec}
-  
+
   \setmainfont[
     Path=fonts/,
     Extension=.otf,
@@ -47,12 +47,12 @@
     \end{tcolorbox}
   }
   \input{\olpath/version}
-  
+
   \definecolor{BackgroundColor}{HTML}{f3f6ed}
   \definecolor{SpineBackColor}{HTML}{262626}
-  
+
   \begin{document}
-  
+
   \begin{bookcover}
     \bookcovercomponent{color}{bg whole}{color=BackgroundColor}
     \bookcovercomponent{color}{spine}{color=SpineBackColor}
@@ -71,7 +71,7 @@
       \vfil
       \vspace*{1cm}
     \end{center}}
-    
+
     \bookcovercomponent{center}{spine}{
       \rotatebox[origin=c]{-90}{\color{orange}
       \Huge\bfseries Category Theory for Programmers \hspace{2em} Bartosz Milewski}}
@@ -85,7 +85,7 @@
           \input{blurb}
           \vspace{.5cm}
         \end{minipage}
-        
+
         \begin{minipage}{.85\textwidth}
           \rule{\textwidth}{.5pt}
 

--- a/src/cover/cover-hardcover-scala.tex
+++ b/src/cover/cover-hardcover-scala.tex
@@ -6,7 +6,7 @@
     11pt,
     marklength=0pt,
   ]{bookcover}
-  
+
   \usepackage{fancybox}
   \usepackage{wrapfig}
   \usepackage[many]{tcolorbox}
@@ -47,12 +47,12 @@
     \end{tcolorbox}
   }
   \input{\olpath/version}
-  
+
   \definecolor{BackgroundColor}{HTML}{f3f6ed}
   \definecolor{SpineBackColor}{HTML}{262626}
-  
+
   \begin{document}
-  
+
   \begin{bookcover}
     \bookcovercomponent{color}{bg whole}{color=BackgroundColor}
     \bookcovercomponent{color}{spine}{color=SpineBackColor}
@@ -71,7 +71,7 @@
       \vfil
       \vspace*{1cm}
     \end{center}}
-    
+
     \bookcovercomponent{center}{spine}{
       \rotatebox[origin=c]{-90}{\color{orange}
       \Huge\bfseries Category Theory for Programmers \hspace{2em} Bartosz Milewski}}
@@ -85,7 +85,7 @@
           \input{blurb}
           \vspace{.5cm}
         \end{minipage}
-        
+
         \begin{minipage}{.85\textwidth}
           \rule{\textwidth}{.5pt}
 

--- a/src/cover/cover-hardcover.tex
+++ b/src/cover/cover-hardcover.tex
@@ -6,14 +6,14 @@
     11pt,
     marklength=0pt,
   ]{bookcover}
-  
+
   \usepackage{fancybox}
   \usepackage{wrapfig}
   \usepackage[many]{tcolorbox}
   \usetikzlibrary{calc,positioning, shadings}
   \usepackage[T1]{fontenc}
-  \usepackage{Alegreya} %% Option 'black' gives heavier bold face 
-  
+  \usepackage{Alegreya} %% Option 'black' gives heavier bold face
+
   \setmainfont{Alegreya Sans}[
     UprightFeatures={SmallCapsFont=* SC},
     ItalicFeatures={SmallCapsFont=* SC Italic},
@@ -42,12 +42,12 @@
     \end{tcolorbox}
   }
   \input{\olpath/version}
-  
+
   \definecolor{BackgroundColor}{HTML}{f3f6ed}
   \definecolor{SpineBackColor}{HTML}{262626}
-  
+
   \begin{document}
-  
+
   \begin{bookcover}
     \bookcovercomponent{color}{bg whole}{color=BackgroundColor}
     \bookcovercomponent{color}{spine}{color=SpineBackColor}
@@ -79,7 +79,7 @@
           \input{blurb}
           \vspace{.5cm}
         \end{minipage}
-        
+
         \begin{minipage}{.85\textwidth}
           \rule{\textwidth}{.5pt}
 

--- a/src/cover/cover-paperback-ocaml.tex
+++ b/src/cover/cover-paperback-ocaml.tex
@@ -7,7 +7,7 @@
     11pt,
     marklength=0in,
   ]{bookcover}
-  
+
   \usepackage{fancybox}
   \usepackage{wrapfig}
   \usepackage[many]{tcolorbox}
@@ -56,12 +56,12 @@
     \end{tcolorbox}
   }
   \input{\olpath/version}
-  
+
   \definecolor{BackgroundColor}{HTML}{f3f6ed}
   \definecolor{SpineBackColor}{HTML}{262626}
-  
+
   \begin{document}
-  
+
   \begin{bookcover}
     \bookcovercomponent{color}{bg whole}{color=BackgroundColor}
     \bookcovercomponent{color}{spine}{color=SpineBackColor}
@@ -80,7 +80,7 @@
       \vfil
       \vspace*{1cm}
     \end{center}}
-    
+
     \bookcovercomponent{center}{spine}{
       \rotatebox[origin=c]{-90}{\color{orange}
       \Huge\bfseries Category Theory for Programmers \hspace{2em} Bartosz Milewski}}
@@ -94,7 +94,7 @@
           \input{blurb}
           \vspace{0.6cm}
         \end{minipage}
-        
+
         \begin{minipage}{.85\textwidth}
           \rule{\textwidth}{.5pt}
 

--- a/src/cover/cover-paperback-reason.tex
+++ b/src/cover/cover-paperback-reason.tex
@@ -7,7 +7,7 @@
     11pt,
     marklength=0in,
   ]{bookcover}
-  
+
   \usepackage{fancybox}
   \usepackage{wrapfig}
   \usepackage[many]{tcolorbox}
@@ -56,12 +56,12 @@
     \end{tcolorbox}
   }
   \input{\olpath/version}
-  
+
   \definecolor{BackgroundColor}{HTML}{f3f6ed}
   \definecolor{SpineBackColor}{HTML}{262626}
-  
+
   \begin{document}
-  
+
   \begin{bookcover}
     \bookcovercomponent{color}{bg whole}{color=BackgroundColor}
     \bookcovercomponent{color}{spine}{color=SpineBackColor}
@@ -80,7 +80,7 @@
       \vfil
       \vspace*{1cm}
     \end{center}}
-    
+
     \bookcovercomponent{center}{spine}{
       \rotatebox[origin=c]{-90}{\color{orange}
       \Huge\bfseries Category Theory for Programmers \hspace{2em} Bartosz Milewski}}
@@ -94,7 +94,7 @@
           \input{blurb}
           \vspace{0.6cm}
         \end{minipage}
-        
+
         \begin{minipage}{.85\textwidth}
           \rule{\textwidth}{.5pt}
 

--- a/src/cover/cover-paperback-scala.tex
+++ b/src/cover/cover-paperback-scala.tex
@@ -7,7 +7,7 @@
     11pt,
     marklength=0in,
   ]{bookcover}
-  
+
   \usepackage{fancybox}
   \usepackage{wrapfig}
   \usepackage[many]{tcolorbox}
@@ -48,12 +48,12 @@
     \end{tcolorbox}
   }
   \input{\olpath/version}
-  
+
   \definecolor{BackgroundColor}{HTML}{f3f6ed}
   \definecolor{SpineBackColor}{HTML}{262626}
-  
+
   \begin{document}
-  
+
   \begin{bookcover}
     \bookcovercomponent{color}{bg whole}{color=BackgroundColor}
     \bookcovercomponent{color}{spine}{color=SpineBackColor}
@@ -72,7 +72,7 @@
       \vfil
       \vspace*{1cm}
     \end{center}}
-    
+
     \bookcovercomponent{center}{spine}{
       \rotatebox[origin=c]{-90}{\color{orange}
       \Huge\bfseries Category Theory for Programmers \hspace{2em} Bartosz Milewski}}
@@ -86,7 +86,7 @@
           \input{blurb}
           \vspace{0.6cm}
         \end{minipage}
-        
+
         \begin{minipage}{.85\textwidth}
           \rule{\textwidth}{.5pt}
 

--- a/src/cover/cover-paperback.tex
+++ b/src/cover/cover-paperback.tex
@@ -6,14 +6,14 @@
     11pt,
     marklength=0pt,
   ]{bookcover}
-  
+
   \usepackage{fancybox}
   \usepackage{wrapfig}
   \usepackage[many]{tcolorbox}
   \usetikzlibrary{calc,positioning, shadings}
   \usepackage[T1]{fontenc}
-  \usepackage{Alegreya} %% Option 'black' gives heavier bold face 
-  
+  \usepackage{Alegreya} %% Option 'black' gives heavier bold face
+
   \setmainfont{Alegreya Sans}[
     UprightFeatures={SmallCapsFont=* SC},
     ItalicFeatures={SmallCapsFont=* SC Italic},
@@ -42,12 +42,12 @@
     \end{tcolorbox}
   }
   \input{\olpath/version}
-  
+
   \definecolor{BackgroundColor}{HTML}{f3f6ed}
   \definecolor{SpineBackColor}{HTML}{262626}
-  
+
   \begin{document}
-  
+
   \begin{bookcover}
     \bookcovercomponent{color}{bg whole}{color=BackgroundColor}
     \bookcovercomponent{color}{spine}{color=SpineBackColor}
@@ -65,7 +65,7 @@
       \vfil
       \vspace*{1cm}
     \end{center}}
-    
+
     \bookcovercomponent{center}{spine}{
       \rotatebox[origin=c]{-90}{\color{orange}
       \Huge\bfseries Category Theory for Programmers \hspace{2em} Bartosz Milewski}}
@@ -79,7 +79,7 @@
           \input{blurb}
           \vspace{.5cm}
         \end{minipage}
-        
+
         \begin{minipage}{.85\textwidth}
           \rule{\textwidth}{.5pt}
 

--- a/src/cover/ribbon-ocaml.tex
+++ b/src/cover/ribbon-ocaml.tex
@@ -15,7 +15,7 @@
     \coordinate (A') at ($(A) + (-\stripwidth,0) $);
 
     \coordinate (B) at ($ (current page.south east) + (0,\stripskip) $);% <-- changed coordinate from 'north' to south' and sign for \stripskip
-    \coordinate (B') at ($(B) + (0,\stripwidth) $);% <-- changed sign for \stripskip 
+    \coordinate (B') at ($(B) + (0,\stripwidth) $);% <-- changed sign for \stripskip
 
     \fill [BurntOrange!20] (A) -- (A') -- (B') -- (B) -- cycle;
 

--- a/src/cover/ribbon-reason.tex
+++ b/src/cover/ribbon-reason.tex
@@ -15,7 +15,7 @@
     \coordinate (A') at ($(A) + (-\stripwidth,0) $);
 
     \coordinate (B) at ($ (current page.south east) + (0,\stripskip) $);% <-- changed coordinate from 'north' to south' and sign for \stripskip
-    \coordinate (B') at ($(B) + (0,\stripwidth) $);% <-- changed sign for \stripskip 
+    \coordinate (B') at ($(B) + (0,\stripwidth) $);% <-- changed sign for \stripskip
 
     \fill [RedOrange!20] (A) -- (A') -- (B') -- (B) -- cycle;
 

--- a/src/cover/ribbon-scala.tex
+++ b/src/cover/ribbon-scala.tex
@@ -11,7 +11,7 @@
     \coordinate (A') at ($(A) + (-\stripwidth,0) $);
 
     \coordinate (B) at ($ (current page.south east) + (0,\stripskip) $);% <-- changed coordinate from 'north' to south' and sign for \stripskip
-    \coordinate (B') at ($(B) + (0,\stripwidth) $);% <-- changed sign for \stripskip 
+    \coordinate (B') at ($(B) + (0,\stripwidth) $);% <-- changed sign for \stripskip
 
     \fill [red!20] (A) -- (A') -- (B') -- (B) -- cycle;
 

--- a/src/half-title.tex
+++ b/src/half-title.tex
@@ -61,6 +61,6 @@ Converted from a series of blog posts by \href{https://bartoszmilewski.com/2014/
 PDF and book compiled by \href{https://hmemcpy.com}{Igal Tabachnik}.\\
 \vspace{1.26em}
 \noindent
-\LaTeX{} source code is available on GitHub: \href{https://github.com/hmemcpy/milewski-ctfp-pdf}{https://github.com/hmemcpy/milewski-ctfp-pdf} 
+\LaTeX{} source code is available on GitHub: \href{https://github.com/hmemcpy/milewski-ctfp-pdf}{https://github.com/hmemcpy/milewski-ctfp-pdf}
 \end{center}
 \end{small}

--- a/src/opt-print-ustrade.tex
+++ b/src/opt-print-ustrade.tex
@@ -8,12 +8,12 @@
 %    https://www.blurb.com/make/pdf_to_book/booksize_calculator
 % 2. Get the specifications. For a 6x9 hardcover (ImageWrap) book, I got:
 %
-%    Page Specifications	                    Inches
-%    Final, exported PDF should measure (w x h)	6.125 x 9.25
-%    Page size / trim line (w x h)	            6.0 x 9.0
-%    Bleed (top, bottom, and outside edges)	    0.125
-%    Safe boundary (Top, Bottom, Outside Edge)	0.25
-%    Safe boundary (Binding Edge)	            0.5
+%    Page Specifications                        Inches
+%    Final, exported PDF should measure (w x h) 6.125 x 9.25
+%    Page size / trim line (w x h)              6.0 x 9.0
+%    Bleed (top, bottom, and outside edges)     0.125
+%    Safe boundary (Top, Bottom, Outside Edge)  0.25
+%    Safe boundary (Binding Edge)               0.5
 %
 % 3. Trim line is at 0.625in, so to get safe text boundary (magenta line):
 %    Top margin:      0.625in (start at trim line, header space fills to safe line)


### PR DESCRIPTION
Since the book focuses heavily on types, I think that the C++ keyword typename is more appropriate, clear and avoids confusion for those less experienced with C++, and I think it's generally good practice to use typename instead of the overloaded meaning of class.

I also added a missing step in the composition argument for fmap Nothing and fixed some whitespace formatting.
There is trailing whitespace in the licence file and in errata-1.0.0.md, but I didn't change them since I think it's more interesting for the readers to know when they were last updated properly.