### PR TITLE
Fix error in type for bimap

### DIFF
--- a/src/content/1.8/code/ocaml/snippet13.ml
+++ b/src/content/1.8/code/ocaml/snippet13.ml
@@ -1,1 +1,1 @@
-val bimap : (a FU.t -> a' FU.t) -> (b GU.t -> b' GU.t) -> (a FU.t, b GU.t) -> (a' FU.t, b' GU.t)
+val bimap : (a FU.t -> a' FU.t) -> (b GU.t -> b' GU.t) -> (a FU.t, b GU.t) t -> (a' FU.t, b' GU.t) t


### PR DESCRIPTION
The `t` I added actually stands for `BiCompBiFunctor.t` but technically `bimap` is defined inside the module so I omitted the module name.