### PR TITLE
Make the second "LaTeX" in the Colophon a macro

### DIFF
--- a/src/colophon.tex
+++ b/src/colophon.tex
@@ -1,7 +1,7 @@
 \lettrine[lraise=-0.03,loversize=0.08]{T}{his book} was compiled by \urlref{https://hmemcpy.com}{Igal Tabachnik}, by converting the original text by Bartosz Milewski into \LaTeX{} format, by
 first scraping the original WordPress blog posts using \urlref{https://mercury.postlight.com/web-parser/}{Mercury Web Parser}
 to get a clean HTML content, modifying and tweaking with \urlref{https://www.crummy.com/software/BeautifulSoup/}{Beautiful Soup},
-finally, converting to LaTeX with \urlref{https://pandoc.org/}{Pandoc}.
+finally, converting to \LaTeX{} with \urlref{https://pandoc.org/}{Pandoc}.
 
 The typefaces are Linux Libertine for body text and Linux Biolinum for headings, both by Philipp H. Poll. Typewriter face is Inconsolata
 created by Raph Levien and supplemented by Dimosthenis Kaponis and Takashi Tanigawa in the form of Inconsolata \acronym{LGC}. The cover page


### PR DESCRIPTION
Well, the colophon uses the word "LaTeX" twice; the latter use was not rendered with the nice macro. This fixes it.