### PR TITLE
Fix formatting in the OCaml snippet

### DIFF
--- a/src/content/1.6/code/ocaml/snippet20.ml
+++ b/src/content/1.6/code/ocaml/snippet20.ml
@@ -1,1 +1,2 @@
-(* OCaml only allows special characters in the infix operator. So, the above function name cannot be applied be infix. *)
+(* OCaml only allows special characters in the infix operator.
+   So, the above function name cannot be applied be infix. *)


### PR DESCRIPTION
See: page 89 of the OCaml version of the book.

Before:

![image](https://user-images.githubusercontent.com/12023585/134456660-a88eda72-65dd-4033-9e38-2c7991a7fc4d.png)

After:

![image](https://user-images.githubusercontent.com/12023585/134456696-edb72761-e95d-4f30-86cb-f0981cfc7faa.png)

