### PR TITLE
Fix formatting in OCaml snippets

### DIFF
--- a/src/content/1.8/code/ocaml/snippet01.ml
+++ b/src/content/1.8/code/ocaml/snippet01.ml
@@ -1,4 +1,5 @@
-(** You can represent bifunctor defintion in two forms and implement just and derive the other from it. *)
+(** You can represent bifunctor defintion in two forms and implement
+    just and derive the other from it. *)
 module type BifunctorCore = sig
   type ('a, 'b) t
 

--- a/src/content/1.8/code/ocaml/snippet09.ml
+++ b/src/content/1.8/code/ocaml/snippet09.ml
@@ -1,4 +1,7 @@
-(** OCaml doesn't support higher kinded types. So, we have to use module functors to emulate the behavior higher kinded types. There's less verbose options using type defunctionalization but it's more advanced and obscures the flow of this book *)
+(** OCaml doesn't support higher kinded types. So, we have to use
+    module functors to emulate the behavior higher kinded types.
+    There's less verbose options using type defunctionalization
+    but it's more advanced and obscures the flow of this book *)
 module type BiComp = functor
   (BF : sig
      type ('a, 'b) t

--- a/src/content/1.8/code/ocaml/snippet14.ml
+++ b/src/content/1.8/code/ocaml/snippet14.ml
@@ -1,4 +1,6 @@
-(** Deriving a functor in OCaml is not available as a language extension. You could try experimental library like ocsigen to derive functors.*)
+(** Deriving a functor in OCaml is not available as a language
+    extension. You could try experimental library like ocsigen
+    to derive functors.*)
 type 'a tree =
   | Leaf of 'a
   | Node of 'a tree * 'a tree

--- a/src/content/3.2/code/ocaml/snippet06.ml
+++ b/src/content/3.2/code/ocaml/snippet06.ml
@@ -1,4 +1,5 @@
-(* Putting it all together to show the equivalence between unit/counit and left_adjunct/right_adjunct *)
+(* Putting it all together to show the equivalence between
+   unit/counit and left_adjunct/right_adjunct *)
 module type Adjunction = functor
   (F : Functor)
   (U : Representable)

--- a/src/content/3.8/code/ocaml/snippet31.ml
+++ b/src/content/3.8/code/ocaml/snippet31.ml
@@ -1,2 +1,3 @@
-(* Gen.t is used to represent infinite data structures like haskell's lazy list *)
+(* Gen.t is used to represent infinite data structures like haskell's
+   lazy list *)
 val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a Gen.t


### PR DESCRIPTION
A few more fixes for OCaml code snippets (related: #277). The problem is that we don't have automatic wrapping for OCaml comments when render them in LaTeX. So we have to set new lines manually.

I found this while reading chapter 8, then I created a [small script](https://gist.github.com/jubnzv/c2c8b2edd4d739a28f32107905235795), which finds similar cases among all code snippets.

<details>
  <summary>Screenshots (before / after)</summary>

![image](https://user-images.githubusercontent.com/12023585/139811408-48842993-ef56-456e-94ba-bcbe36c2b0e7.png)

![image](https://user-images.githubusercontent.com/12023585/139811482-83061c1a-74dd-4d69-9dcc-2b1a0c7164d9.png)

![image](https://user-images.githubusercontent.com/12023585/139811557-a6443222-4b57-48ee-87af-457d7a036ef0.png)

![image](https://user-images.githubusercontent.com/12023585/139811596-1f09fa3f-ca0d-40e2-99ae-ea09dcba94fc.png)

![image](https://user-images.githubusercontent.com/12023585/139811641-1af42700-4618-4f1b-bc91-0b812c3a9cb8.png)
</details>