### PR TITLE
Add missing comma

### DIFF
--- a/src/content/1.2/types-and-functions.tex
+++ b/src/content/1.2/types-and-functions.tex
@@ -24,7 +24,7 @@ grammatical errors. Lots of monkeys will go without bananas, but the
 remaining programs will have a better chance of being useful. Type
 checking provides yet another barrier against nonsensical programs.
 Moreover, whereas in a dynamically typed language, type mismatches would
-be discovered at runtime, in strongly typed statically checked languages
+be discovered at runtime, in strongly typed statically checked languages,
 type mismatches are discovered at compile time, eliminating lots of
 incorrect programs before they have a chance to run.
 
@@ -408,7 +408,7 @@ can be defined as follows:
 to define a Boolean type in C++ as an enumeration:
 
 \begin{snip}{cpp}
-enum bool { 
+enum bool {
     true,
     false
 };
@@ -468,7 +468,7 @@ std::getchar()
 \end{minted}
   \item
 \begin{minted}{cpp}
-bool f() { 
+bool f() {
     std::cout << "Hello!" << std::endl;
     return true;
 }


### PR DESCRIPTION
Added a missing comma.

My neovim settings also automatically removed trailing whitespaces and added a newline at the end in the process. I figured I should keep it as is and ask whether that should be reverted or not.