### PR TITLE
Fix missing apostrophe

### DIFF
--- a/src/content/1.7/functors.tex
+++ b/src/content/1.7/functors.tex
@@ -193,7 +193,7 @@ easy:
 = { definition of id }
   id (Just x)
 \end{snip}
-Now, lets show that \code{fmap} preserves composition:
+Now, let's show that \code{fmap} preserves composition:
 
 \src{snippet09}
 First the \code{Nothing} case:


### PR DESCRIPTION
Fix missing apostrophe: "Now, lets show..." -> "Now, let's show...".