### PR TITLE
Revert wrong "typo fix" for "iff"

### DIFF
--- a/src/content/3.2/adjunctions.tex
+++ b/src/content/3.2/adjunctions.tex
@@ -271,7 +271,7 @@ Similarly, we can map the target object $c$ using $R$. Now
 we have two objects in $\cat{D}$, $d$ and $R c$. They,
 too, define a hom set:
 \[\cat{D}(d, R c)\]
-We say that $L$ is left adjoint to $R$ if there is an
+We say that $L$ is left adjoint to $R$ iff there is an
 isomorphism of hom sets:
 \[\cat{C}(L d, c) \cong \cat{D}(d, R c)\]
 that is natural both in $d$ and $c$.


### PR DESCRIPTION
- 'iff' normally means 'if and only if', which is stronger than just 'if'. https://en.wikipedia.org/wiki/If_and_only_if
- See the discussion on #294