### PR TITLE
Use `\mathit` for multi-letter identifiers

### DIFF
--- a/src/category.tex
+++ b/src/category.tex
@@ -14,4 +14,4 @@
 \newcommand{\Ran}{\mathbf{Ran}}
 \newcommand{\Lan}{\mathbf{Lan}}
 \newcommand{\Hask}{\mathbf{Hask}}
-\newcommand{\Fop}{\cat{F}^{op}}
+\newcommand{\Fop}{\cat{F}^\mathit{op}}

--- a/src/content/1.5/products-and-coproducts.tex
+++ b/src/content/1.5/products-and-coproducts.tex
@@ -128,14 +128,14 @@ the definition of the terminal object to just one type.
 You can't help but to notice the symmetry between the way we defined the
 initial object and the terminal object. The only difference between the
 two was the direction of morphisms. It turns out that for any category $\cat{C}$
-we can define the \newterm{opposite category} $\cat{C}^{op}$ just by
+we can define the \newterm{opposite category} $\cat{C}^\mathit{op}$ just by
 reversing all the arrows. The opposite category automatically satisfies
 all the requirements of a category, as long as we simultaneously
 redefine composition. If original morphisms
 $f \Colon a \to b$ and $g \Colon b \to c$ composed
 to $h \Colon a \to c$ with $h = g \circ f$, then the reversed
-morphisms $f^{op} \Colon b \to a$ and $g^{op} \Colon c \to b$ will compose to
-$h^{op} \Colon c \to a$ with $h^{op} = f^{op} \circ g^{op}$. And reversing
+morphisms $f^\mathit{op} \Colon b \to a$ and $g^\mathit{op} \Colon c \to b$ will compose to
+$h^\mathit{op} \Colon c \to a$ with $h^\mathit{op} = f^\mathit{op} \circ g^\mathit{op}$. And reversing
 the identity arrows is a (pun alert!) no-op.
 
 Duality is a very important property of categories because it doubles
@@ -445,7 +445,7 @@ union. For instance, a tagged union of an \code{int} and a
 \code{char const *} could be implemented as:
 
 \begin{snip}{cpp}
-struct Contact { 
+struct Contact {
     enum { isPhone, isEmail } tag;
     union { int phoneNum; char const * emailAddr; };
 };
@@ -455,7 +455,7 @@ functions. For instance, here's the first injection as a function
 \code{PhoneNum}:
 
 \begin{snip}{cpp}
-Contact PhoneNum(int n) { 
+Contact PhoneNum(int n) {
     Contact c;
     c.tag = isPhone;
     c.phoneNum = n;
@@ -623,7 +623,7 @@ int m(Either const & e);
         Still continuing: What about these injections?
 
         \begin{snip}{cpp}
-int i(int n) { 
+int i(int n) {
     if (n < 0) return n;
     return n + 2;
 }

--- a/src/content/1.8/functoriality.tex
+++ b/src/content/1.8/functoriality.tex
@@ -458,15 +458,15 @@ returned \code{a} instead. We can't invert an arbitrary function, but
 we can go to the opposite category.
 
 A short recap: For every category $\cat{C}$ there is a dual category
-$\cat{C}^{op}$. It's a category with the same objects as
+$\cat{C}^\mathit{op}$. It's a category with the same objects as
 $\cat{C}$, but with all the arrows reversed.
 
-Consider a functor that goes between $\cat{C}^{op}$ and
+Consider a functor that goes between $\cat{C}^\mathit{op}$ and
 some other category $\cat{D}$:
-\[F \Colon \cat{C}^{op} \to \cat{D}\]
-Such a functor maps a morphism $f^{op} \Colon a \to b$ in
-$\cat{C}^{op}$ to the morphism $F f^{op} \Colon F a \to F b$ in $\cat{D}$. But the morphism
-$f^{op}$ secretly corresponds to some morphism
+\[F \Colon \cat{C}^\mathit{op} \to \cat{D}\]
+Such a functor maps a morphism $f^\mathit{op} \Colon a \to b$ in
+$\cat{C}^\mathit{op}$ to the morphism $F f^\mathit{op} \Colon F a \to F b$ in $\cat{D}$. But the morphism
+$f^\mathit{op}$ secretly corresponds to some morphism
 $f \Colon b \to a$ in the original category $\cat{C}$. Notice the
 inversion.
 
@@ -475,8 +475,8 @@ define based on $F$, which is not a functor --- let's call it
 $G$. It's a mapping from $\cat{C}$ to $\cat{D}$. It maps objects the
 same way $F$ does, but when it comes to mapping morphisms, it
 reverses them. It takes a morphism $f \Colon b \to a$ in $\cat{C}$, maps
-it first to the opposite morphism $f^{op} \Colon a \to b$
-and then uses the functor $F$ on it, to get $F f^{op} \Colon F a \to F b$.
+it first to the opposite morphism $f^\mathit{op} \Colon a \to b$
+and then uses the functor $F$ on it, to get $F f^\mathit{op} \Colon F a \to F b$.
 
 Considering that $F a$ is the same as $G a$ and $F b$ is
 the same as $G b$, the whole trip can be described as: $G f \Colon (b \to a) \to (G a \to G b)$
@@ -522,7 +522,7 @@ beast? It turns out that, if the target category is $\Set$, such a
 beast is called a \newterm{profunctor}. Because a contravariant functor is
 equivalent to a covariant functor from the opposite category, a
 profunctor is defined as:
-\[\cat{C}^{op} \times \cat{D} \to \Set\]
+\[\cat{C}^\mathit{op} \times \cat{D} \to \Set\]
 Since, to first approximation, Haskell types are sets, we apply the name
 \code{Profunctor} to a type constructor \code{p} of two arguments,
 which is contra-functorial in the first argument and functorial in the
@@ -557,10 +557,10 @@ The above examples are the reflection of a more general statement that
 the mapping that takes a pair of objects $a$ and $b$ and
 assigns to it the set of morphisms between them, the hom-set
 $\cat{C}(a, b)$, is a functor. It is a functor from the product
-category $\cat{C}^{op}\times{}\cat{C}$ to the category of sets, $\Set$.
+category $\cat{C}^\mathit{op}\times{}\cat{C}$ to the category of sets, $\Set$.
 
 Let's define its action on morphisms. A morphism in
-$\cat{C}^{op}\times{}\cat{C}$ is a pair of morphisms from $\cat{C}$:
+$\cat{C}^\mathit{op}\times{}\cat{C}$ is a pair of morphisms from $\cat{C}$:
 \begin{gather*}
   f \Colon a' \to a \\
   g \Colon b \to b'

--- a/src/content/1.9/function-types.tex
+++ b/src/content/1.9/function-types.tex
@@ -154,10 +154,10 @@ of this as a symbolic name for one object, not to be confused with a
 Haskell typeclass constraint --- I'll discuss different ways of naming
 it later). This object comes with its own application --- a morphism
 from $(a \Rightarrow b) \times a$ to $b$ --- which we will call
-$eval$. The object \code{$a \Rightarrow b$} is the best if any other
+$\mathit{eval}$. The object \code{$a \Rightarrow b$} is the best if any other
 candidate for a function object can be uniquely mapped to it in such a
 way that its application morphism $g$ factorizes through
-$eval$. This object is better than any other object according to
+$\mathit{eval}$. This object is better than any other object according to
 our ranking.
 
 \begin{figure}[H]
@@ -175,13 +175,13 @@ Formally:
   \begin{minipage}[t]{0.97\columnwidth}\raggedright\strut
     A \emph{function object} from $a$ to $b$ is an object
     $a \Rightarrow b$ together with the morphism
-    \[eval \Colon ((a \Rightarrow b) \times a) \to b\]
+    \[\mathit{eval} \Colon ((a \Rightarrow b) \times a) \to b\]
     such that for any other object $z$ with a morphism
     \[g \Colon z \times a \to b\]
     there is a unique morphism
     \[h \Colon z \to (a \Rightarrow b)\]
-    that factors $g$ through $eval$:
-    \[g = eval \circ (h \times \id)\]
+    that factors $g$ through $\mathit{eval}$:
+    \[g = \mathit{eval} \circ (h \times \id)\]
   \end{minipage}\tabularnewline
   \bottomrule
 \end{longtable}
@@ -221,7 +221,7 @@ variable returning functions. This correspondence is called
 This correspondence is one-to-one, because given any $g$ there is
 a unique $h$, and given any $h$ you can always recreate
 the two-argument function $g$ using the formula:
-\[g = eval \circ (h \times \id)\]
+\[g = \mathit{eval} \circ (h \times \id)\]
 The function $g$ can be called the \emph{uncurried} version of $h$.
 
 Currying is essentially built into the syntax of Haskell. A function
@@ -522,7 +522,7 @@ It takes a pair consisting of a function and its argument and produces a
 result of the appropriate type. It's the Haskell implementation of the
 morphism:
 
-\[eval \Colon (a \Rightarrow b) \times a \to b\]
+\[\mathit{eval} \Colon (a \Rightarrow b) \times a \to b\]
 which defines the function type $a \Rightarrow b$ (or the exponential object
 $b^{a}$). Let's translate this signature to a logical predicate
 using the Curry-Howard isomorphism:
@@ -563,7 +563,7 @@ Finally, we come to the meaning of the \code{absurd} function:
 \src{snippet15}
 Considering that \code{Void} translates into false, we get:
 
-\[false \Rightarrow a\]
+\[\mathit{false} \Rightarrow a\]
 Anything follows from falsehood (\emph{ex falso quodlibet}). Here's one
 possible proof (implementation) of this statement (function) in Haskell:
 

--- a/src/content/2.2/limits-and-colimits.tex
+++ b/src/content/2.2/limits-and-colimits.tex
@@ -239,23 +239,23 @@ characteristic of a \emph{contravariant} functor.
 To define a natural transformation, we need another functor that's also
 a mapping from $\cat{C}$ to $\Set$. But this time we'll consider a
 set of cones. Cones are just natural transformations, so we are looking
-at the set of natural transformations $Nat(\Delta_c, D)$. The mapping
+at the set of natural transformations $\mathit{Nat}(\Delta_c, D)$. The mapping
 from \code{c} to this particular set of natural transformations is a
 (contravariant) functor. How can we show that? Again, let's define its
 action on a morphism:
 \[f \Colon c' \to c\]
 The lifting of $f$ should be a mapping of natural transformations
 between two functors that go from $\cat{I}$ to $\cat{C}$:
-\[Nat(\Delta_c, D) \to Nat(\Delta_{c'}, D)\]
+\[\mathit{Nat}(\Delta_c, D) \to \mathit{Nat}(\Delta_{c'}, D)\]
 How do we map natural transformations? Every natural transformation is a
 selection of morphisms --- its components --- one morphism per element
-of $\cat{I}$. A component of some $\alpha$ (a member of $Nat(\Delta_c, D)$) at
+of $\cat{I}$. A component of some $\alpha$ (a member of $\mathit{Nat}(\Delta_c, D)$) at
 $a$ (an object in $\cat{I}$) is a morphism:
 \[\alpha_a \Colon \Delta_c a \to D a\]
 or, using the definition of the constant functor $\Delta$,
 \[\alpha_a \Colon c \to D a\]
 Given $f$ and $\alpha$, we have to construct a $\beta$, a member of
-$Nat(\Delta_{c'}, D)$. Its component at $a$ should be a
+$\mathit{Nat}(\Delta_{c'}, D)$. Its component at $a$ should be a
 morphism:
 \[\beta_a \Colon c' \to D a\]
 We can easily get the latter ($\beta_a$) from the former ($\alpha_a$) by precomposing it with
@@ -273,7 +273,7 @@ natural transformation.
 Given our morphism $f$, we have thus built a mapping between two
 natural transformations, component-wise. This mapping defines
 \code{contramap} for the functor:
-\[c \to Nat(\Delta_c, D)\]
+\[c \to \mathit{Nat}(\Delta_c, D)\]
 What I have just done is to show you that we have two (contravariant)
 functors from $\cat{C}$ to $\Set$. I haven't made any assumptions
 --- these functors always exist.
@@ -290,7 +290,7 @@ between them. So without further ado, here's the conclusion: A functor
 $D$ from $\cat{I}$ to $\cat{C}$ has a limit $\Lim[D]$ if and
 only if there is a natural isomorphism between the two functors I have
 just defined:
-\[\cat{C}(c, \Lim[D]) \simeq Nat(\Delta_c, D)\]
+\[\cat{C}(c, \Lim[D]) \simeq \mathit{Nat}(\Delta_c, D)\]
 Let me remind you what a natural isomorphism is. It's a natural
 transformation whose every component is an isomorphism, that is to say
 an invertible morphism.
@@ -304,7 +304,7 @@ higher order functions, because they go from the hom-set to the set of
 natural transformations. Again, you can analyze a function by
 considering what it does to its argument: here the argument will be a
 morphism --- a member of $\cat{C}(c, \Lim[D])$ --- and the result will
-be a natural transformation --- a member of $Nat(\Delta_c, D)$, or
+be a natural transformation --- a member of $\mathit{Nat}(\Delta_c, D)$, or
 what we have called a cone. This natural transformation, in turn, has
 its own components, which are morphisms. So it's morphisms all the way
 down, and if you can keep track of them, you can prove the statement.
@@ -314,7 +314,7 @@ isomorphism is exactly the commutativity condition for the mapping of
 cones.
 
 As a preview of coming attractions, let me mention that the set
-$Nat(\Delta_c, D)$ can be thought of as a hom-set in the functor
+$\mathit{Nat}(\Delta_c, D)$ can be thought of as a hom-set in the functor
 category; so our natural isomorphism relates two hom-sets, which points
 at an even more general relationship called an adjunction.
 
@@ -520,7 +520,7 @@ It will also come up with a set of constraints resulting from the rules
 of function application:
 
 \begin{snip}{haskell}
-t0 = t1 -> t2 -- because f is applied to x 
+t0 = t1 -> t2 -- because f is applied to x
 t0 = t2 -> t3 -- because f is applied to (f x)
 \end{snip}
 These constraints have to be unified by finding a set of types (or type
@@ -528,7 +528,7 @@ variables) that, when substituted for the unknown types in both
 expressions, produce the same type. One such substitution is:
 
 \begin{snip}{haskell}
-t1 = t2 = t3 = Int 
+t1 = t2 = t3 = Int
 twice :: (Int -> Int) -> Int -> Int
 \end{snip}
 but, obviously, it's not the most general one. The most general
@@ -609,7 +609,7 @@ not available in $\cat{C}$.
 A hom-functor is an example of a continuous functor. Recall that the
 hom-functor, $\cat{C}(a, b)$, is contravariant in the first variable
 and covariant in the second. In other words, it's a functor:
-\[\cat{C}^{op} \times \cat{C} \to \Set\]
+\[\cat{C}^\mathit{op} \times \cat{C} \to \Set\]
 When its second argument is fixed, the hom-set functor (which becomes
 the representable presheaf) maps colimits in $\cat{C}$ to limits in
 $\Set$; and when its first argument is fixed, it maps limits to

--- a/src/content/2.4/representable-functors.tex
+++ b/src/content/2.4/representable-functors.tex
@@ -126,7 +126,7 @@ The important lesson is that this observation holds in any category: the
 mapping of objects to hom-sets is functorial. Since contravariance is
 equivalent to a mapping from the opposite category, we can state this
 fact succinctly as:
-\[C(-, =) \Colon \cat{C}^{op} \times \cat{C} \to \Set\]
+\[C(-, =) \Colon \cat{C}^\mathit{op} \times \cat{C} \to \Set\]
 
 \section{Representable Functors}
 
@@ -263,8 +263,8 @@ cover a whole family of functions with arbitrary return types.
 
 Representability for contravariant functors is similarly defined, except
 that we keep the second argument of $\cat{C}(-, a)$ fixed. Or,
-equivalently, we may consider functors from $\cat{C}^{op}$
-to $\Set$, because $\cat{C}^{op}(a, -)$ is the same as
+equivalently, we may consider functors from $\cat{C}^\mathit{op}$
+to $\Set$, because $\cat{C}^\mathit{op}(a, -)$ is the same as
 $\cat{C}(-, a)$.
 
 There is an interesting twist to representability. Remember that

--- a/src/content/2.5/the-yoneda-lemma.tex
+++ b/src/content/2.5/the-yoneda-lemma.tex
@@ -293,7 +293,7 @@ compositional properties of \acronym{CPS}.
 
 As usual, we get a bonus construction by inverting the direction of
 arrows. The Yoneda lemma can be applied to the opposite category
-$\cat{C}^{op}$ to give us a mapping between contravariant
+$\cat{C}^\mathit{op}$ to give us a mapping between contravariant
 functors.
 
 Equivalently, we can derive the co-Yoneda lemma by fixing the target

--- a/src/content/2.6/yoneda-embedding.tex
+++ b/src/content/2.6/yoneda-embedding.tex
@@ -88,7 +88,7 @@ The (contravariant) functor we have just described, the functor that
 maps objects in $\cat{C}$ to functors in $[\cat{C}, \Set]$:
 \[a \to \cat{C}(a, -)\]
 defines the \newterm{Yoneda embedding}. It \emph{embeds} a category
-$\cat{C}$ (strictly speaking, the category $\cat{C}^{op}$,
+$\cat{C}$ (strictly speaking, the category $\cat{C}^\mathit{op}$,
 because of contravariance) inside the functor category
 $[\cat{C}, \Set]$. It not only maps objects in $\cat{C}$ to
 functors, but also faithfully preserves all connections between them.

--- a/src/content/3.10/ends-and-coends.tex
+++ b/src/content/3.10/ends-and-coends.tex
@@ -12,12 +12,12 @@ of ``proofs.'' This mapping is functorial --- contravariant in the first
 argument and covariant in the second. We can look at it as establishing
 a global relationship between objects in the category. This relationship
 is described by the hom-functor:
-\[\cat{C}(-, =) \Colon \cat{C}^{op}\times{}\cat{C} \to \Set\]
+\[\cat{C}(-, =) \Colon \cat{C}^\mathit{op}\times{}\cat{C} \to \Set\]
 In general, any functor like this may be interpreted as establishing a
 relation between objects in a category. A relation may also involve two
 different categories $\cat{C}$ and $\cat{D}$. A functor, which describes
 such a relation, has the following signature and is called a profunctor:
-\[p \Colon \cat{D}^{op}\times{}\cat{C} \to \Set\]
+\[p \Colon \cat{D}^\mathit{op}\times{}\cat{C} \to \Set\]
 Mathematicians say that it's a profunctor from $\cat{C}$ to $\cat{D}$
 (notice the inversion), and use a slashed arrow as a symbol for it:
 \[\cat{C} \nrightarrow \cat{D}\]
@@ -71,7 +71,7 @@ transformation is called a dinatural transformation, provided it
 satisfies the commuting conditions that reflect the two ways we can
 connect diagonal elements to non-diagonal ones. A dinatural
 transformation between two profunctors $p$ and $q$, which
-are members of the functor category ${[}\cat{C}^{op}\times{}\cat{C}, \Set{]}$, is a
+are members of the functor category ${[}\cat{C}^\mathit{op}\times{}\cat{C}, \Set{]}$, is a
 family of morphisms:
 \[\alpha_a \Colon p\ a\ a \to q\ a\ a\]
 for which the following diagram commutes, for any $f \Colon a \to b$:
@@ -84,7 +84,7 @@ for which the following diagram commutes, for any $f \Colon a \to b$:
 \noindent
 Notice that this is strictly weaker than the naturality condition. If
 $\alpha$ were a natural transformation in
-${[}\cat{C}^{op}\times{}\cat{C}, \Set{]}$, the above diagram could be constructed
+${[}\cat{C}^\mathit{op}\times{}\cat{C}, \Set{]}$, the above diagram could be constructed
 from two naturality squares and one functoriality condition (profunctor
 $q$ preserving composition):
 
@@ -95,7 +95,7 @@ $q$ preserving composition):
 
 \noindent
 Notice that a component of a natural transformation $\alpha$ in
-${[}\cat{C}^{op}\times{}\cat{C}, \Set{]}$ is indexed by a pair of objects
+${[}\cat{C}^\mathit{op}\times{}\cat{C}, \Set{]}$ is indexed by a pair of objects
 $\alpha_{a b}$. A dinatural transformation, on the other hand, is
 indexed by one object, since it only maps diagonal elements of the
 respective profunctors.
@@ -117,7 +117,7 @@ $\Set$-valued profunctors), and the sides are a family of
 functions mapping the apex to the sets in the base. You may think of
 this family as one polymorphic function --- a function that's
 polymorphic in its return type:
-\[\alpha \Colon \forall a\ .\ apex \to p\ a\ a\]
+\[\alpha \Colon \forall a\ .\ \mathit{apex} \to p\ a\ a\]
 Unlike in cones, within a wedge we don't have any functions that would
 connect vertices of the base. However, as we've seen earlier, given any
 morphism $f \Colon a \to b$ in $\cat{C}$, we can connect both

--- a/src/content/3.12/enriched-categories.tex
+++ b/src/content/3.12/enriched-categories.tex
@@ -236,7 +236,7 @@ either empty or a singleton. We interpret a non-empty set
 $\cat{C}(a, b)$ as the proof that $a$ is less than or equal to
 $b$. Such a category can be interpreted as enriched over a very
 simple monoidal category that contains just two objects, $0$ and $1$
-(sometimes called $False$ and $True$). Besides the mandatory identity
+(sometimes called $\mathit{False}$ and $\mathit{True}$). Besides the mandatory identity
 morphisms, this category has a single morphism going from $0$ to $1$, let's
 call it $0 \to 1$. A simple monoidal structure can be
 established in it, with the tensor product modeling the simple

--- a/src/content/3.13/topoi.tex
+++ b/src/content/3.13/topoi.tex
@@ -108,8 +108,8 @@ subset, and ``false'' to those that aren't.
 It remains to specify what it means to designate an element of
 $\Omega$ as ``true.'' We can use the standard trick: use a function
 from a singleton set to $\Omega$. We'll call this function
-$true$:
-\[true \Colon 1 \to \Omega\]
+$\mathit{true}$:
+\[\mathit{true} \Colon 1 \to \Omega\]
 
 \begin{figure}[H]
   \centering
@@ -120,17 +120,17 @@ $true$:
 These definitions can be combined in such a way that they not only
 define what a subobject is, but also define the special object
 $\Omega$ without talking about elements. The idea is that we want the
-morphism $true$ to represent a ``generic'' subobject. In
+morphism $\mathit{true}$ to represent a ``generic'' subobject. In
 $\Set$, it picks a single-element subset from a two-element set
 $\Omega$. This is as generic as it gets. It's clearly a proper subset,
 because $\Omega$ has one more element that's \emph{not} in that
 subset.
 
-In a more general setting, we define $true$ to be a monomorphism
+In a more general setting, we define $\mathit{true}$ to be a monomorphism
 from the terminal object to the \emph{classifying object} $\Omega$.
 But we have to define the classifying object. We need a universal
 property that links this object to the characteristic function. It turns
-out that, in $\Set$, the pullback of $true$ along the
+out that, in $\Set$, the pullback of $\mathit{true}$ along the
 characteristic function $\chi$ defines both the subset $a$
 and the injective function that embeds it in $b$. Here's the
 pullback diagram:
@@ -142,8 +142,8 @@ pullback diagram:
 
 \noindent
 Let's analyze this diagram. The pullback equation is:
-\[true\ .\ unit = \chi\ .\ f\]
-The function $true\ .\ unit$ maps every element of $a$ to
+\[\mathit{true}\ .\ \mathit{unit} = \chi\ .\ f\]
+The function $\mathit{true}\ .\ \mathit{unit}$ maps every element of $a$ to
 ``true.'' Therefore $f$ must map all elements of $a$ to
 those elements of $b$ for which $\chi$ is ``true.'' These
 are, by definition, the elements of the subset that is specified by the
@@ -153,7 +153,7 @@ $f$ is injective.
 
 This pullback diagram can be used to define the classifying object in
 categories other than $\Set$. Such a category must have a terminal
-object, which will let us define the monomorphism $true$. It must
+object, which will let us define the monomorphism $\mathit{true}$. It must
 also have pullbacks --- the actual requirement is that it must have all
 finite limits (a pullback is an example of a finite limit). Under those
 assumptions, we define the classifying object $\Omega$ by the property
@@ -162,14 +162,14 @@ $\chi$ that completes the pullback diagram.
 
 Let's analyze the last statement. When we construct a pullback, we are
 given three objects $\Omega$, $b$ and $1$; and two
-morphisms, $true$ and $\chi$. The existence of a pullback
+morphisms, $\mathit{true}$ and $\chi$. The existence of a pullback
 means that we can find the best such object $a$, equipped with
-two morphisms $f$ and $unit$ (the latter is uniquely
+two morphisms $f$ and $\mathit{unit}$ (the latter is uniquely
 determined by the definition of the terminal object), that make the
 diagram commute.
 
 Here we are solving a different system of equations. We are solving for
-$\Omega$ and $true$ while varying both $a$ \emph{and}
+$\Omega$ and $\mathit{true}$ while varying both $a$ \emph{and}
 $b$. For a given $a$ and $b$ there may or may not
 be a monomorphism $f \Colon a \to b$. But if there is one, we
 want it to be a pullback of some $\chi$. Moreover, we want this
@@ -184,12 +184,12 @@ equivalent monomorphisms to $b$. This family of monomorphisms is
 in one-to-one correspondence with the family of equivalent pullbacks of
 our diagram.
 
-We can thus define a set of subobjects of $b$, $Sub(b)$,
+We can thus define a set of subobjects of $b$, $\mathit{Sub}(b)$,
 as a family of monomorphisms, and see that it is isomorphic to the set
 of morphisms from $b$ to $\Omega$:
-\[Sub(b) \cong \cat{C}(b, \Omega)\]
+\[\mathit{Sub}(b) \cong \cat{C}(b, \Omega)\]
 This happens to be a natural isomorphism of two functors. In other
-words, $Sub(-)$ is a representable (contravariant) functor whose
+words, $\mathit{Sub}(-)$ is a representable (contravariant) functor whose
 representation is the object $\Omega$.
 
 \section{Topos}
@@ -221,7 +221,7 @@ this is true are called Boolean.
 
 In set theory, a characteristic function may be interpreted as defining
 a property of the elements of a set --- a \newterm{predicate} that is true
-for some elements and false for others. The predicate $isEven$
+for some elements and false for others. The predicate $\mathit{isEven}$
 selects a subset of even numbers from the set of natural numbers. In a
 topos, we can generalize the idea of a predicate to be a morphism from
 object $a$ to $\Omega$. This is why $\Omega$ is sometimes
@@ -254,5 +254,5 @@ logics.
   \tightlist
   \item
         Show that the function $f$ that is the pullback of
-        $true$ along the characteristic function must be injective.
+        $\mathit{true}$ along the characteristic function must be injective.
 \end{enumerate}

--- a/src/content/3.14/lawvere-theories.tex
+++ b/src/content/3.14/lawvere-theories.tex
@@ -400,7 +400,7 @@ category:
 When restricted to finite sets, this becomes:
 \[m \to T n\]
 The category opposite to this Kleisli category,
-$\cat{Kl}^{op}_{T}$, restricted to finite
+$\cat{Kl}^\mathit{op}_{T}$, restricted to finite
 sets, is the Lawvere theory in question. In particular, the hom-set
 $\cat{L}(n, 1)$ that describes n-ary operations in $\cat{L}$ is given
 by the hom-set $\cat{Kl}_{T}(1, n)$.

--- a/src/content/3.15/monads-monoids-and-categories.tex
+++ b/src/content/3.15/monads-monoids-and-categories.tex
@@ -239,12 +239,12 @@ bicategories.
 
 Let's construct a monad in $\cat{Span}$. We pick a $0$-cell, which is a
 set that, for reasons that will become clear soon, I will call
-$Ob$. Next, we pick an endo-$1$-cell: a span from $Ob$ back
-to $Ob$. It has a set at the apex, which I will call $Ar$,
+$\mathit{Ob}$. Next, we pick an endo-$1$-cell: a span from $\mathit{Ob}$ back
+to $\mathit{Ob}$. It has a set at the apex, which I will call $\mathit{Ar}$,
 equipped with two functions:
 \begin{align*}
-  dom & \Colon Ar \to Ob \\
-  cod & \Colon Ar \to Ob
+  \mathit{dom} & \Colon \mathit{Ar} \to \mathit{Ob} \\
+  \mathit{cod} & \Colon \mathit{Ar} \to \mathit{Ob}
 \end{align*}
 
 \begin{figure}[H]
@@ -253,21 +253,21 @@ equipped with two functions:
 \end{figure}
 
 \noindent
-Let's call the elements of the set $Ar$ ``arrows.'' If I also
-tell you to call the elements of $Ob$ ``objects,'' you might get
-a hint where this is leading to. The two functions $dom$ and
-$cod$ assign the domain and the codomain to an ``arrow.''
+Let's call the elements of the set $\mathit{Ar}$ ``arrows.'' If I also
+tell you to call the elements of $\mathit{Ob}$ ``objects,'' you might get
+a hint where this is leading to. The two functions $\mathit{dom}$ and
+$\mathit{cod}$ assign the domain and the codomain to an ``arrow.''
 
 To make our span into a monad, we need two $2$-cells, $\eta$ and
 $\mu$. The monoidal unit, in this case, is the trivial span from
-$Ob$ to $Ob$ with the apex at $Ob$ and two identity
+$\mathit{Ob}$ to $\mathit{Ob}$ with the apex at $\mathit{Ob}$ and two identity
 functions. The $2$-cell $\eta$ is a function between the apices
-$Ob$ and $Ar$. In other words, $\eta$ assigns an
+$\mathit{Ob}$ and $\mathit{Ar}$. In other words, $\eta$ assigns an
 ``arrow'' to every ``object.'' A $2$-cell in $\cat{Span}$ must satisfy
 commutation conditions --- in this case:
 \begin{align*}
-  dom & \circ \eta = \id \\
-  cod & \circ \eta = \id
+  \mathit{dom} & \circ \eta = \id \\
+  \mathit{cod} & \circ \eta = \id
 \end{align*}
 
 \begin{figure}[H]
@@ -277,17 +277,17 @@ commutation conditions --- in this case:
 
 \noindent
 In components, this becomes:
-\[dom\ (\eta\ ob) = ob = cod\ (\eta\ ob)\]
-where $ob$ is an ``object'' in $Ob$. In other words,
+\[\mathit{dom}\ (\eta\ \mathit{ob}) = \mathit{ob} = \mathit{cod}\ (\eta\ \mathit{ob})\]
+where $\mathit{ob}$ is an ``object'' in $\mathit{Ob}$. In other words,
 $\eta$ assigns to every ``object'' and ``arrow'' whose domain and
 codomain are that ``object.'' We'll call this special ``arrow'' the
 ``identity arrow.''
 
 The second $2$-cell $\mu$ acts on the composition of the span
-$Ar$ with itself. The composition is defined as a pullback, so
-its elements are pairs of elements from $Ar$ --- pairs of
+$\mathit{Ar}$ with itself. The composition is defined as a pullback, so
+its elements are pairs of elements from $\mathit{Ar}$ --- pairs of
 ``arrows'' $(a_1, a_2)$. The pullback condition is:
-\[cod\ a_1 = dom\ a_2\]
+\[\mathit{cod}\ a_1 = \mathit{dom}\ a_2\]
 We say that $a_1$ and $a_2$ are ``composable,'' because the
 domain of one is the codomain of the other.
 
@@ -299,7 +299,7 @@ domain of one is the codomain of the other.
 \noindent
 The $2$-cell $\mu$ is a function that maps a pair of composable
 arrows $(a_1, a_2)$ to a single arrow $a_3$ from
-$Ar$. In other words $\mu$ defines composition of arrows.
+$\mathit{Ar}$. In other words $\mu$ defines composition of arrows.
 
 It's easy to check that monad laws correspond to identity and
 associativity laws for arrows. We have just defined a category (a small

--- a/src/content/3.2/adjunctions.tex
+++ b/src/content/3.2/adjunctions.tex
@@ -350,13 +350,13 @@ can treat the category of Haskell types as the category of sets.
 
 When the right category $\cat{D}$ is $\Set$, the right adjoint
 $R$ is a functor from $\cat{C}$ to $\Set$. Such a functor is
-representable if we can find an object $rep$ in $\cat{C}$ such
-that the hom-functor $\cat{C}(rep, \_)$ is naturally isomorphic to
+representable if we can find an object $\mathit{rep}$ in $\cat{C}$ such
+that the hom-functor $\cat{C}(\mathit{rep}, \_)$ is naturally isomorphic to
 $R$. It turns out that, if $R$ is the right adjoint of
 some functor $L$ from $\Set$ to $\cat{C}$, such an object
 always exists --- it's the image of the singleton set $()$ under
 $L$:
-\[rep = L ()\]
+\[\mathit{rep} = L ()\]
 Indeed, the adjunction tells us that the following two hom-sets are
 naturally isomorphic:
 \[\cat{C}(L (), c) \cong \Set((), R c)\]
@@ -378,11 +378,11 @@ product-like candidate through the universal product.
 
 More precisely, the product of two objects $a$ and $b$ is
 the object $(a\times{}b)$ (or \code{(a, b)} in the Haskell
-notation) equipped with two morphisms $fst$ and $snd$ such
+notation) equipped with two morphisms $\mathit{fst}$ and $\mathit{snd}$ such
 that, for any other candidate $c$ equipped with two morphisms
 $p \Colon c \to a$ and $q \Colon c \to b$, there
 exists a unique morphism $m \Colon c \to (a, b)$ that
-factorizes $p$ and $q$ through $fst$ and $snd$.
+factorizes $p$ and $q$ through $\mathit{fst}$ and $\mathit{snd}$.
 
 As we've seen earlier, in Haskell, we can implement a \code{factorizer} that generates this
 morphism from the two projections:
@@ -504,10 +504,10 @@ To summarize what we have done: A categorical product may be defined
 globally as the \newterm{right adjoint} of the diagonal functor:
 \[(\cat{C}\times{}\cat{C})(\Delta c, \langle a, b \rangle) \cong \cat{C}(c, a\times{}b)\]
 Here, $a\times{}b$ is the result of the action of our right adjoint
-functor $Product$ on the pair
+functor $\mathit{Product}$ on the pair
 $\langle a, b \rangle$. Notice that any functor from
-$\cat{C}\times{}\cat{C}$ is a bifunctor, so $Product$ is a bifunctor. In
-Haskell, the $Product$ bifunctor is written simply as
+$\cat{C}\times{}\cat{C}$ is a bifunctor, so $\mathit{Product}$ is a bifunctor. In
+Haskell, the $\mathit{Product}$ bifunctor is written simply as
 \code{(,)}. You can apply it to two types and get their product type,
 for instance:
 
@@ -546,7 +546,7 @@ redrawing the diagram that we used in the universal construction.
 \end{figure}
 
 \noindent
-Notice that the $eval$ morphism\footnote{See ch.9 on \hyperref[function-types]{universal
+Notice that the $\mathit{eval}$ morphism\footnote{See ch.9 on \hyperref[function-types]{universal
     construction}.} is nothing else but the counit of
 this adjunction:
 \[(a \Rightarrow b)\times{}a \to b\]

--- a/src/content/3.6/monads-categorically.tex
+++ b/src/content/3.6/monads-categorically.tex
@@ -388,7 +388,7 @@ we have to establish that it's a bifunctor. Can it be used to lift a
 pair of morphisms --- here, natural transformations? The signature of
 the analog of \code{bimap} for the tensor product would look something
 like this:
-\[bimap \Colon (a \to b) \to (c \to d) \to (a \otimes c \to b \otimes d)\]
+\[\mathit{bimap} \Colon (a \to b) \to (c \to d) \to (a \otimes c \to b \otimes d)\]
 If you replace objects by endofunctors, arrows by natural
 transformations, and tensor products by composition, you get:
 \[(F \to F') \to (G \to G') \to (F \circ G \to F' \circ G')\]

--- a/src/content/3.8/f-algebras.tex
+++ b/src/content/3.8/f-algebras.tex
@@ -160,9 +160,9 @@ rigorous later.
 
 Applying an endofunctor infinitely many times produces a \newterm{fixed
   point}, an object defined as:
-\[Fix\ f = f\ (Fix\ f)\]
+\[\mathit{Fix}\ f = f\ (\mathit{Fix}\ f)\]
 The intuition behind this definition is that, since we applied
-$f$ infinitely many times to get $Fix\ f$, applying it one
+$f$ infinitely many times to get $\mathit{Fix}\ f$, applying it one
 more time doesn't change anything. In Haskell, the definition of a fixed
 point is:
 

--- a/src/content/3.9/algebras-for-monads.tex
+++ b/src/content/3.9/algebras-for-monads.tex
@@ -27,23 +27,23 @@ conditions. The components of these transformations at $a$ are:
 \end{align*}
 An algebra for the same endofunctor is a selection of a particular
 object --- the carrier $a$ --- together with the morphism:
-\[alg \Colon m\ a \to a\]
+\[\mathit{alg} \Colon m\ a \to a\]
 The first thing to notice is that the algebra goes in the opposite
 direction to $\eta_a$. The intuition is that $\eta_a$ creates a
 trivial expression from a value of type $a$. The first coherence
 condition that makes the algebra compatible with the monad ensures that
 evaluating this expression using the algebra whose carrier is $a$
 gives us back the original value:
-\[alg \circ \eta_a = \id_a\]
+\[\mathit{alg} \circ \eta_a = \id_a\]
 The second condition arises from the fact that there are two ways of
 evaluating the doubly nested expression $m\ (m\ a)$. We can first
 apply $\mu_a$ to flatten the expression, and then use the evaluator
 of the algebra; or we can apply the lifted evaluator to evaluate the
 inner expressions, and then apply the evaluator to the result. We'd like
 the two strategies to be equivalent:
-\[alg \circ \mu_a = alg \circ m\ alg\]
+\[\mathit{alg} \circ \mu_a = \mathit{alg} \circ m\ \mathit{alg}\]
 Here, \code{m alg} is the morphism resulting from lifting
-$alg$ using the functor $m$. The following commuting
+$\mathit{alg}$ using the functor $m$. The following commuting
 diagrams describe the two conditions (I replaced $m$ with
 $T$ in anticipation of what follows):
 
@@ -53,7 +53,7 @@ $T$ in anticipation of what follows):
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
       a \arrow[rd, equal] \arrow[r, "\eta_a"]
-      & Ta \arrow[d, "alg"] \\
+      & Ta \arrow[d, "\mathit{alg}"] \\
       & a
     \end{tikzcd}
   \end{subfigure}
@@ -61,9 +61,9 @@ $T$ in anticipation of what follows):
   \begin{subfigure}
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
-      T(Ta) \arrow[r, "T\ alg"] \arrow[d, "\mu_a"]
-      & Ta \arrow[d, "alg"] \\
-      Ta \arrow[r, "alg"]
+      T(Ta) \arrow[r, "T\ \mathit{alg}"] \arrow[d, "\mu_a"]
+      & Ta \arrow[d, "\mathit{alg}"] \\
+      Ta \arrow[r, "\mathit{alg}"]
       & a
     \end{tikzcd}
   \end{subfigure}
@@ -130,8 +130,8 @@ evaluator.
 We still have to show that this is a T-algebra. For that, two coherence
 conditions must be satisfied:
 \begin{align*}
-  alg & \circ \eta_{Ta} = \id_{Ta}     \\
-  alg & \circ \mu_a = alg \circ T\ alg
+  \mathit{alg} & \circ \eta_{Ta} = \id_{Ta}     \\
+  \mathit{alg} & \circ \mu_a = \mathit{alg} \circ T\ \mathit{alg}
 \end{align*}
 But these are just monadic laws, if you plug in $\mu$ for the
 algebra.
@@ -331,7 +331,7 @@ with a comonad. They make the following diagrams commute:
     \begin{tikzcd}[column sep=large, row sep=large]
       a \arrow[rd, equal]
       & Wa \arrow[l, "\epsilon_a"'] \\
-      & a \arrow[u, "coa"']
+      & a \arrow[u, "\mathit{coa}"']
     \end{tikzcd}
   \end{subfigure}%
   \hspace{1cm}
@@ -339,17 +339,17 @@ with a comonad. They make the following diagrams commute:
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
       W(Wa)
-      & Wa \arrow[l, "W\ coa"'] \\
+      & Wa \arrow[l, "W\ \mathit{coa}"'] \\
       Wa \arrow[u, "\delta_a"]
-      & a \arrow[u, "coa"] \arrow[l, "coa"']
+      & a \arrow[u, "\mathit{coa}"] \arrow[l, "\mathit{coa}"']
     \end{tikzcd}
   \end{subfigure}
 \end{figure}
 
 \noindent
-where $coa$ is the coevaluation morphism of the coalgebra whose
+where $\mathit{coa}$ is the coevaluation morphism of the coalgebra whose
 carrier is $a$:
-\[coa \Colon a \to W a\]
+\[\mathit{coa} \Colon a \to W a\]
 and $\varepsilon$ and $\delta$ are the two natural transformations
 defining the comonad (in Haskell, their components are called
 \code{extract} and \code{duplicate}).
@@ -371,34 +371,34 @@ and regenerate the comonad from the corresponding adjunction.
 
 Let's go back to our discussion of lenses. A lens can be written as a
 coalgebra:
-\[coalg_s \Colon a \to Store\ s\ a\]
-for the functor $Store\ s$:
+\[\mathit{coalg}_s \Colon a \to \mathit{Store}\ s\ a\]
+for the functor $\mathit{Store}\ s$:
 
 \src{snippet07}
 This coalgebra can be also expressed as a pair of functions:
 \begin{align*}
-  set & \Colon a \to s \to a \\
-  get & \Colon a \to s
+  \mathit{set} & \Colon a \to s \to a \\
+  \mathit{get} & \Colon a \to s
 \end{align*}
 (Think of $a$ as standing for ``all,'' and $s$ as a
 ``small'' part of it.) In terms of this pair, we have:
-\[coalg_s\ a = Store\ (set\ a)\ (get\ a)\]
+\[\mathit{coalg}_s\ a = \mathit{Store}\ (\mathit{set}\ a)\ (\mathit{get}\ a)\]
 Here, $a$ is a value of type $a$. Notice that partially
 applied \code{set} is a function $s \to a$.
 
-We also know that $Store\ s$ is a comonad:
+We also know that $\mathit{Store}\ s$ is a comonad:
 
 \src{snippet08}
 The question is: Under what conditions is a lens a coalgebra for this
 comonad? The first coherence condition:
-\[\varepsilon_a \circ coalg = \idarrow[a]\]
+\[\varepsilon_a \circ \mathit{coalg} = \idarrow[a]\]
 translates to:
-\[set\ a\ (get\ a) = a\]
+\[\mathit{set}\ a\ (\mathit{get}\ a) = a\]
 This is the lens law that expresses the fact that if you set a field of
 the structure $a$ to its previous value, nothing changes.
 
 The second condition:
-\[fmap\ coalg \circ coalg = \delta_a \circ coalg\]
+\[\mathit{fmap}\ \mathit{coalg} \circ \mathit{coalg} = \delta_a \circ \mathit{coalg}\]
 requires a little more work. First, recall the definition of
 \code{fmap} for the \code{Store} functor:
 


### PR DESCRIPTION
By default, in math environment, each letter is a separate identifier or variable, so a consecutive sequence of letters typically means multiplication of several variables. To represent a multi-letter identifier, it’s better to wrap it in `\mathit{}`. Without `\mathit{}`, the result identifier would have awkward spacings between each letter.