### PR TITLE
Small fixes

### DIFF
--- a/src/content/1.7/functors.tex
+++ b/src/content/1.7/functors.tex
@@ -30,10 +30,10 @@ functor preserves the structure of a category: what's connected in one
 category will be connected in the other category. But there's something
 more to the structure of a category: there's also the composition of
 morphisms. If $h$ is a composition of $f$ and $g$:
-\[h = g . f\]
+\[h = g \circ f\]
 we want its image under $F$ to be a composition of the images of $f$
 and $g$:
-\[F h = F g~.~F f\]
+\[F h = F g \circ F f\]
 
 \begin{figure}[H]
   \centering
@@ -267,7 +267,7 @@ management issues characteristic of C++):
 
 \begin{snip}{cpp}
 template<class T>
-class optional { 
+class optional {
     bool _isValid; // the tag
     T _v;
 public:
@@ -284,11 +284,11 @@ functions:
 \begin{snip}{cpp}
 template<class A, class B>
 std::function<optional<B>(optional<A>)>
-fmap(std::function<B(A)> f) { 
-    return [f](optional<A> opt) { 
-        if (!opt.isValid()) 
+fmap(std::function<B(A)> f) {
+    return [f](optional<A> opt) {
+        if (!opt.isValid())
             return optional<B>{};
-        else 
+        else
             return optional<B>{ f(opt.val()) };
     };
 }
@@ -298,10 +298,10 @@ returning a function. Here's the uncurried version of it:
 
 \begin{snip}{cpp}
 template<class A, class B>
-optional<B> fmap(std::function<B(A)> f, optional<A> opt) { 
+optional<B> fmap(std::function<B(A)> f, optional<A> opt) {
     if (!opt.isValid())
         return optional<B>{};
-    else 
+    else
         return optional<B>{ f(opt.val()) };
 }
 \end{snip}
@@ -396,9 +396,9 @@ back to the original definition of the uncurried \code{fmap}:
 
 \begin{snip}{cpp}
 template<class A, class B>
-optional<B> fmap(std::function<B(A)> f, optional<A> opt) { 
-    if (!opt.isValid()) 
-        return optional<B>{}; 
+optional<B> fmap(std::function<B(A)> f, optional<A> opt) {
+    if (!opt.isValid())
+        return optional<B>{};
     else
         return optional<B>{ f(opt.val()) };
 }
@@ -462,7 +462,7 @@ std::vector<B> fmap(std::function<B(A)> f, std::vector<A> v) {
     std::transform( std::begin(v)
                   , std::end(v)
                   , std::back_inserter(w)
-                  , f); 
+                  , f);
     return w;
 }
 \end{snip}
@@ -612,7 +612,7 @@ arguments --- which are compile-time --- and values, which are run-time:
 
 \begin{snip}{cpp}
 template<class C, class A>
-struct Const { 
+struct Const {
     Const(C v) : _v(v) {}
     C _v;
 };

--- a/src/content/2.2/limits-and-colimits.tex
+++ b/src/content/2.2/limits-and-colimits.tex
@@ -222,7 +222,7 @@ $\cat{C}(c', \Lim[D])$. An element of a hom-set is a morphism, so
 we have:
 \[u \Colon c \to \Lim[D]\]
 We can precompose $u$ with $f$ to get:
-\[u . f \Colon c' \to \Lim[D]\]
+\[u \circ f \Colon c' \to \Lim[D]\]
 And that's an element of $\cat{C}(c', \Lim[D])$--- so indeed, we
 have found a mapping of morphisms:
 
@@ -240,7 +240,7 @@ To define a natural transformation, we need another functor that's also
 a mapping from $\cat{C}$ to $\Set$. But this time we'll consider a
 set of cones. Cones are just natural transformations, so we are looking
 at the set of natural transformations $\mathit{Nat}(\Delta_c, D)$. The mapping
-from \code{c} to this particular set of natural transformations is a
+from $c$ to this particular set of natural transformations is a
 (contravariant) functor. How can we show that? Again, let's define its
 action on a morphism:
 \[f \Colon c' \to c\]
@@ -260,7 +260,7 @@ morphism:
 \[\beta_a \Colon c' \to D a\]
 We can easily get the latter ($\beta_a$) from the former ($\alpha_a$) by precomposing it with
 $f$:
-\[\beta_a = \alpha_a . f\]
+\[\beta_a = \alpha_a \circ f\]
 It's relatively easy to show that those components indeed add up to a
 natural transformation.
 


### PR DESCRIPTION
This PR contains two fixes:

1. Use small circles for morphism compositions in math environment.
2. Replace a `\code{c}` with `$c$`, because only `$c$` is referred in the context, `\code{c}` does not make sense.