### PR TITLE
self referencing fi in freeFunctor snippet10.scala

### DIFF
--- a/src/content/3.11/code/scala/snippet10.scala
+++ b/src/content/3.11/code/scala/snippet10.scala
@@ -2,7 +2,7 @@ implicit def freeFunctor[F[_]] = new Functor[FreeF[F, ?]] {
   def fmap[A, B](g: A => B)(fa: FreeF[F, A]): FreeF[F, B] = {
     new FreeF[F, B] {
       def h[I]: I => B = g compose fa.h
-      def fi[I]: F[I] = fi
+      def fi[I]: F[I] = fa.fi
     }
   }
 }


### PR DESCRIPTION
Replace the self referencing `fi` in `freeFunctor` definition `snippet10.scala`