### PR TITLE
Fix category font style

### DIFF
--- a/src/content/1.10/natural-transformations.tex
+++ b/src/content/1.10/natural-transformations.tex
@@ -68,7 +68,7 @@ and $G f$ in $\cat{D}$:
   G f \Colon G a \to G b
 \end{gather*}
 The natural transformation $\alpha$ provides two additional morphisms
-that complete the diagram in \emph{D}:
+that complete the diagram in $\cat{D}$:
 
 \begin{gather*}
   \alpha_a \Colon F a \to G a \\

--- a/src/content/2.4/representable-functors.tex
+++ b/src/content/2.4/representable-functors.tex
@@ -299,7 +299,7 @@ explore alternative implementations that have practical value.
 \begin{enumerate}
   \tightlist
   \item
-        Show that the hom-functors map identity morphisms in \emph{C} to
+        Show that the hom-functors map identity morphisms in $\cat{C}$ to
         corresponding identity functions in $\Set$.
   \item
         Show that \code{Maybe} is not representable.

--- a/src/content/3.1/its-all-about-morphisms.tex
+++ b/src/content/3.1/its-all-about-morphisms.tex
@@ -98,7 +98,7 @@ These conditions, too, may be replaced by naturality. You may recall
 that the \emph{universal} cone, or the limit, is defined as a natural
 transformation between the (contravariant) hom-functor:
 \[F \Colon c \to \cat{C}(c, \Lim[D])\]
-and the (also contravariant) functor that maps objects in \emph{C} to
+and the (also contravariant) functor that maps objects in $\cat{C}$ to
 cones, which themselves are natural transformations:
 \[G \Colon c \to \cat{Nat}(\Delta_c, D)\]
 Here, $\Delta_c$ is the constant functor, and $D$ is the functor


### PR DESCRIPTION
I think these `C`s and `D` represent category, so it’s better to use a font style for category.