### PR TITLE
Use consistent epsilon symbol

### DIFF
--- a/src/content/3.2/adjunctions.tex
+++ b/src/content/3.2/adjunctions.tex
@@ -157,7 +157,7 @@ diagrams commute:
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
       L \arrow[rd, equal] \arrow[r, "L \circ \eta"]
-      & L \circ R \circ L \arrow[d, "\epsilon \circ L"] \\
+      & L \circ R \circ L \arrow[d, "\varepsilon \circ L"] \\
       & L
     \end{tikzcd}
   \end{subfigure}%
@@ -166,7 +166,7 @@ diagrams commute:
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
       R \arrow[rd, equal] \arrow[r, "\eta \circ R"]
-      & R \circ L \circ R \arrow[d, "R \circ \epsilon"] \\
+      & R \circ L \circ R \arrow[d, "R \circ \varepsilon"] \\
       & R
     \end{tikzcd}
   \end{subfigure}

--- a/src/content/3.9/algebras-for-monads.tex
+++ b/src/content/3.9/algebras-for-monads.tex
@@ -330,7 +330,7 @@ with a comonad. They make the following diagrams commute:
     \centering
     \begin{tikzcd}[column sep=large, row sep=large]
       a \arrow[rd, equal]
-      & Wa \arrow[l, "\epsilon_a"'] \\
+      & Wa \arrow[l, "\varepsilon_a"'] \\
       & a \arrow[u, "\mathit{coa}"']
     \end{tikzcd}
   \end{subfigure}%


### PR DESCRIPTION
Replace `\epsilon` with `\varepsilon` for consistency.