### PR TITLE
Small fixes for 1.6

### DIFF
--- a/src/content/1.6/simple-algebraic-data-types.tex
+++ b/src/content/1.6/simple-algebraic-data-types.tex
@@ -99,7 +99,7 @@ instance, let's define a value \code{stmt} as a pair of
 \code{String} and \code{Bool}:
 
 \src{snippet10}
-The first line is the type declaration. It uses the type constructor
+The first line is the type signature. It uses the type constructor
 \code{Pair}, with \code{String} and \code{Bool} replacing
 \code{a} and the \code{b} in the generic definition of
 \code{Pair}. The second line defines the actual value by passing a

--- a/src/content/1.6/simple-algebraic-data-types.tex
+++ b/src/content/1.6/simple-algebraic-data-types.tex
@@ -390,10 +390,10 @@ about types. Here's a translation table with some entries of interest:
   \endhead
   $0$          & \code{Void}\tabularnewline
   $1$          & \code{()}\tabularnewline
-  $a + b$      & \code{Either a b = Left a | Right b}\tabularnewline
-  $a \times b$ & \code{(a, b)} or \code{Pair a b = Pair a b}\tabularnewline
+  $a + b$      & \code{data Either a b = Left a | Right b}\tabularnewline
+  $a \times b$ & \code{(a, b)} or \code{data Pair a b = Pair a b}\tabularnewline
   $2 = 1 + 1$  & \code{data Bool = True | False}\tabularnewline
-  $1 + a$      & \code{data Maybe = Nothing | Just a}\tabularnewline
+  $1 + a$      & \code{data Maybe a = Nothing | Just a}\tabularnewline
   \bottomrule
 \end{longtable}
 
@@ -451,7 +451,7 @@ semiring, and it too can be mapped into type theory:
   \endhead
   $\mathit{false}$     & \code{Void}\tabularnewline
   $\mathit{true}$      & \code{()}\tabularnewline
-  $a \mathbin{||} b$   & \code{Either a b = Left a | Right b}\tabularnewline
+  $a \mathbin{||} b$   & \code{data Either a b = Left a | Right b}\tabularnewline
   $a \mathbin{\&\&} b$ & \code{(a, b)}\tabularnewline
   \bottomrule
 \end{longtable}

--- a/src/content/1.6/simple-algebraic-data-types.tex
+++ b/src/content/1.6/simple-algebraic-data-types.tex
@@ -357,7 +357,7 @@ Here's the function that converts them one way:
 and here's one that goes the other way:
 
 \src{snippet35}
-The \code{case of} statement is used for pattern matching inside
+The \code{case of} clause is used for pattern matching inside
 functions. Each pattern is followed by an arrow and the expression to be
 evaluated when the pattern matches. For instance, if you call
 \code{prodToSum} with the value:

--- a/src/content/1.6/simple-algebraic-data-types.tex
+++ b/src/content/1.6/simple-algebraic-data-types.tex
@@ -254,7 +254,7 @@ empty list:
 
 \begin{snip}{cpp}
 template<class A>
-class List { 
+class List {
     Node<A> * _head;
 public:
     List() : _head(nullptr) {} // Nil
@@ -472,7 +472,7 @@ talk about function types.
         Here's a sum type defined in Haskell:
 
         \begin{snip}{haskell}
-data Shape = Circle Float 
+data Shape = Circle Float
            | Rect Float Float
 \end{snip}
         When we want to define a function like \code{area} that acts on a

--- a/src/content/1.9/function-types.tex
+++ b/src/content/1.9/function-types.tex
@@ -466,7 +466,7 @@ algebraic identity has a very practical interpretation. It tells us
 that a function from a sum of two types is equivalent to a pair of
 functions from individual types. This is just the case analysis that we
 use when defining functions on sums. Instead of writing one function
-definition with a \code{case} statement, we usually split it into two
+definition with a \code{case} clause, we usually split it into two
 (or more) functions dealing with each type constructor separately. For
 instance, take a function from the sum type
 \code{(Either Int Double)}:

--- a/src/content/2.2/limits-and-colimits.tex
+++ b/src/content/2.2/limits-and-colimits.tex
@@ -627,7 +627,7 @@ in this case a product of two function types:
 
 \src{snippet18}
 Indeed, any function of \code{Either b c} is implemented as a case
-statement with the two cases being serviced by a pair of functions.
+clause with the two cases being serviced by a pair of functions.
 
 Similarly, when we fix the first argument of the hom-set, we get the
 familiar reader functor. Its continuity means that, for instance, any

--- a/src/content/3.10/ends-and-coends.tex
+++ b/src/content/3.10/ends-and-coends.tex
@@ -368,7 +368,7 @@ to a polymorphic function. This makes perfect sense, because such a
 function must be prepared to handle any one of the types that may be
 encoded in the existential type. It's the same principle that tells us
 that a function that accepts a sum type must be implemented as a case
-statement, with a tuple of handlers, one for every type present in the
+clause, with a tuple of handlers, one for every type present in the
 sum. Here, the sum type is replaced by a coend, and a family of handlers
 becomes an end, or a polymorphic function.
 


### PR DESCRIPTION
There are some suggestions from a reviewer of the Japanese version for the chapter 1.6:

- `case of` is a clause, not a statement
- Add missing `data` keyword
- `stmt :: Pair String Bool` is a type signature, not a type declaration
- Remove trailing spaces in Haskell code