### PR TITLE
fix: Use math font for functors

### DIFF
--- a/src/content/1.10/natural-transformations.tex
+++ b/src/content/1.10/natural-transformations.tex
@@ -424,7 +424,7 @@ Composition of natural transformations is associative, because their
 components, which are regular morphisms, are associative with respect to
 their composition.
 
-Finally, for each functor F there is an identity natural transformation
+Finally, for each functor $F$ there is an identity natural transformation
 $1_F$ whose components are the identity morphisms:
 \[\id_{F a} \Colon F a \to F a\]
 So, indeed, functors form a category.

--- a/src/content/3.1/its-all-about-morphisms.tex
+++ b/src/content/3.1/its-all-about-morphisms.tex
@@ -73,8 +73,8 @@ functor; or the other way around. The two directions are orthogonal. A
 natural transformation moves you left and right, and the functors move
 you up and down or back and forth --- so to speak. You can visualize the
 \emph{image} of a functor as a sheet in the target category. A natural
-transformation maps one such sheet corresponding to F, to another,
-corresponding to G.
+transformation maps one such sheet corresponding to $F$, to another,
+corresponding to $G$.
 
 \begin{figure}[H]
   \centering


### PR DESCRIPTION
I found some functors are rendered with normal font instead of math font.