### PR TITLE
Use math font for functors, F-algebras and T-algebras 

### DIFF
--- a/src/content/3.7/comonads.tex
+++ b/src/content/3.7/comonads.tex
@@ -222,7 +222,7 @@ can be easily made bidirectional or extended to two or more dimensions.
 \section{Comonad Categorically}
 
 Defining a comonad in category theory is a straightforward exercise in
-duality. As with the monad, we start with an endofunctor \code{T}. The
+duality. As with the monad, we start with an endofunctor $T$. The
 two natural transformations, $\eta$ and $\mu$, that define the monad are simply
 reversed for the comonad:
 \begin{align*}

--- a/src/content/3.8/f-algebras.tex
+++ b/src/content/3.8/f-algebras.tex
@@ -73,9 +73,9 @@ and concentrate on the final product. The sum of products on the left
 hand side of our morphism defines an endofunctor. What if we pick an
 arbitrary endofunctor $F$ instead? In that case we don't have to
 impose any constraints on our category. What we obtain is called an
-F-algebra.
+$F$-algebra.
 
-An F-algebra is a triple consisting of an endofunctor $F$, an
+An $F$-algebra is a triple consisting of an endofunctor $F$, an
 object $a$, and a morphism
 \[F a \to a\]
 The object is often called the carrier, an underlying object or, in the
@@ -84,7 +84,7 @@ called the evaluation function or the structure map. Think of the
 functor $F$ as forming expressions and the morphism as evaluating
 them.
 
-Here's the Haskell definition of an F-algebra:
+Here's the Haskell definition of an $F$-algebra:
 
 \src{snippet01}
 It identifies the algebra with its evaluation function.
@@ -106,7 +106,7 @@ An example of a ring is the set of integers. We can choose
 as:
 
 \src{snippet04}
-There are more F-algebras based on the same functor \code{RingF}. For
+There are more $F$-algebras based on the same functor \code{RingF}. For
 instance, polynomials form a ring and so do square matrices.
 
 As you can see, the role of the functor is to generate expressions that
@@ -129,7 +129,7 @@ This is still not very practical, since we are forced to represent all
 integers as sums of ones, but it will do in a pinch.
 
 But how can we describe expression trees using the language of
-F-algebras? We have to somehow formalize the process of replacing the
+$F$-algebras? We have to somehow formalize the process of replacing the
 free type variable in the definition of our functor, recursively, with
 the result of the replacement. Imagine doing this in steps. First,
 define a depth-one tree as:
@@ -182,7 +182,7 @@ application:
 The two functions are the inverse of each other. We'll use these
 functions later.
 
-\section{Category of F-Algebras}
+\section{Category of $F$-Algebras}
 
 Here's the oldest trick in the book: Whenever you come up with a way of
 constructing some new objects, see if they form a category. Not
@@ -193,13 +193,13 @@ $F a \to a$, both from the original category
 $\cat{C}$.
 
 To complete the picture, we have to define morphisms in the category of
-F-algebras. A morphism must map one algebra $(a, f)$ to another
+$F$-algebras. A morphism must map one algebra $(a, f)$ to another
 algebra $(b, g)$. We'll define it as a morphism $m$ that
 maps the carriers --- it goes from $a$ to $b$ in the
 original category. Not any morphism will do: we want it to be compatible
 with the two evaluators. (We call such a structure-preserving morphism a
 \newterm{homomorphism}.) Here's how you define a homomorphism of
-F-algebras. First, notice that we can lift $m$ to the mapping:
+$F$-algebras. First, notice that we can lift $m$ to the mapping:
 \[F m \Colon F a \to F b\]
 we can then follow it with $g$ to get to $b$.
 Equivalently, we can use $f$ to go from $F a$ to
@@ -217,13 +217,13 @@ It's easy to convince yourself that this is indeed a category (hint:
 identity morphisms from $\cat{C}$ work just fine, and a composition of
 homomorphisms is a homomorphism).
 
-An initial object in the category of F-algebras, if it exists, is called
+An initial object in the category of $F$-algebras, if it exists, is called
 the \newterm{initial algebra}. Let's call the carrier of this initial
 algebra $i$ and its evaluator $j \Colon F i \to i$. It turns out that $j$,
 the evaluator of the initial algebra, is an isomorphism. This result is
 known as Lambek's theorem. The proof relies on the definition of the
 initial object, which requires that there be a unique homomorphism
-$m$ from it to any other F-algebra. Since $m$ is a
+$m$ from it to any other $F$-algebra. Since $m$ is a
 homomorphism, the following diagram must commute:
 
 \begin{figure}[H]
@@ -289,7 +289,7 @@ the fixed point does not depend on $a$.
 
 \section{Natural Numbers}
 
-Natural numbers can also be defined as an F-algebra. The starting point
+Natural numbers can also be defined as an $F$-algebra. The starting point
 is the pair of morphisms:
 \begin{align*}
   zero & \Colon 1 \to N \\

--- a/src/content/3.9/algebras-for-monads.tex
+++ b/src/content/3.9/algebras-for-monads.tex
@@ -103,19 +103,19 @@ lists, and then fold the resulting list. Again, if we interpret
 binary operation is associative. These conditions are certainly
 fulfilled when \code{(a, f, z)} is a monoid.
 
-\section{T-algebras}
+\section{$T$-algebras}
 
 Since mathematicians prefer to call their monads $T$, they call
-algebras compatible with them T-algebras. T-algebras for a given monad $T$
+algebras compatible with them $T$-algebras. $T$-algebras for a given monad $T$
 in a category $\cat{C}$ form a category called the Eilenberg-Moore
 category, often denoted by $\cat{C}^T$. Morphisms in that
 category are homomorphisms of algebras. These are the same homomorphisms
-we've seen defined for F-algebras.
+we've seen defined for $F$-algebras.
 
-A T-algebra is a pair consisting of a carrier object and an evaluator,
+A $T$-algebra is a pair consisting of a carrier object and an evaluator,
 $(a, f)$. There is an obvious forgetful functor $U^T$ from
 $\cat{C}^T$ to $\cat{C}$, which maps $(a, f)$ to $a$. It
-also maps a homomorphism of T-algebras to a corresponding morphism
+also maps a homomorphism of $T$-algebras to a corresponding morphism
 between carrier objects in $\cat{C}$. You may remember from our discussion of
 adjunctions that the left adjoint to a forgetful functor is called a
 free functor.
@@ -127,7 +127,7 @@ $T (T a)$ back to $T a$. Since $T$ is a monad,
 we can use the monadic $\mu_a$ (\code{join} in Haskell) as the
 evaluator.
 
-We still have to show that this is a T-algebra. For that, two coherence
+We still have to show that this is a $T$-algebra. For that, two coherence
 conditions must be satisfied:
 \begin{align*}
   \mathit{alg} & \circ \eta_{Ta} = \id_{Ta}     \\
@@ -161,17 +161,17 @@ unit of this adjunction.
 
 Let's look at the counit:
 \[\varepsilon \Colon F^T \circ U^T \to I\]
-Let's calculate its component at some T-algebra $(a, f)$. The
+Let's calculate its component at some $T$-algebra $(a, f)$. The
 forgetful functor forgets the $f$, and the free functor produces
 the pair $(T a, \mu_a)$. So in order to define the component of
 the counit $\varepsilon$ at $(a, f)$, we need the right morphism in
-the Eilenberg-Moore category, or a homomorphism of T-algebras:
+the Eilenberg-Moore category, or a homomorphism of $T$-algebras:
 \[(T a, \mu_a) \to (a, f)\]
 Such a homomorphism should map the carrier $T a$ to $a$.
 Let's just resurrect the forgotten evaluator $f$. This time we'll
-use it as a homomorphism of T-algebras. Indeed, the same commuting
-diagram that makes $f$ a T-algebra may be re-interpreted to show
-that it's a homomorphism of T-algebras:
+use it as a homomorphism of $T$-algebras. Indeed, the same commuting
+diagram that makes $f$ a $T$-algebra may be re-interpreted to show
+that it's a homomorphism of $T$-algebras:
 
 \begin{figure}[H]
   \centering
@@ -185,7 +185,7 @@ that it's a homomorphism of T-algebras:
 
 \noindent
 We have thus defined the component of the counit natural transformation
-$\varepsilon$ at $(a, f)$ (an object in the category of T-algebras)
+$\varepsilon$ at $(a, f)$ (an object in the category of $T$-algebras)
 to be $f$.
 
 To complete the adjunction we also need to show that the unit and the
@@ -214,7 +214,7 @@ counit satisfy triangular identities. These are:
 
 \noindent
 The first one holds because of the unit law for the monad $T$.
-The second is just the law of the T-algebra $(a, f)$.
+The second is just the law of the $T$-algebra $(a, f)$.
 
 We have established that the two functors form an adjunction:
 \[F^T \dashv U^T\]

--- a/src/ctfp.tex
+++ b/src/ctfp.tex
@@ -91,7 +91,7 @@
 \chapter{Comonads}\label{comonads}
 \subfile{content/3.7/comonads}
 
-\chapter{F-Algebras}\label{f-algebras}
+\chapter{$F$-Algebras}\label{f-algebras}
 \subfile{content/3.8/f-algebras}
 
 \chapter{Algebras for Monads}\label{algebras-for-monads}


### PR DESCRIPTION
These are usually written in Italics. For example, in "Categories for the Working Mathematicians":
https://www.google.co.jp/books/edition/Categories_for_the_Working_Mathematician/6KPSBwAAQBAJ?gbpv=1&pg=PA137
