### PR TITLE
fix: Lens library name should be lower-case

### DIFF
--- a/src/content/3.7/comonads.tex
+++ b/src/content/3.7/comonads.tex
@@ -375,7 +375,7 @@ the \code{duplicate}d \code{Store} it produces the original
 \code{extract . duplicate = id}).
 
 The \code{Store} comonad plays an important role as the theoretical
-basis for the \code{Lens} library. Conceptually, the
+basis for the \code{lens} library. Conceptually, the
 \code{Store s a} comonad encapsulates the idea of ``focusing'' (like
 a lens) on a particular substructure of the data type \code{a} using
 the type \code{s} as an index. In particular, a function of the type:


### PR DESCRIPTION
cf. https://hackage.haskell.org/package/lens