### PR TITLE
Function definition requires argument, not type

### DIFF
--- a/src/content/3.10/code/haskell/snippet02.hs
+++ b/src/content/3.10/code/haskell/snippet02.hs
@@ -1,1 +1,1 @@
-dimap f id (p b b) :: p a b
+dimap f id pbb :: p a b

--- a/src/content/3.10/code/haskell/snippet03.hs
+++ b/src/content/3.10/code/haskell/snippet03.hs
@@ -1,1 +1,1 @@
-dimap id f (p a a) :: p a b
+dimap id f paa :: p a b


### PR DESCRIPTION
In `dimap` code in 3.10, [original blog](https://bartoszmilewski.com/2017/03/29/ends-and-coends/#:~:text=dimap%20f%20id%20pbb%20%3A%3A%20p%20a%20b) uses the `pbb` and `paa`, but it was replaced with the `(p b b)` and `(p a a)` in PR #66.  I propose rolling back that change.

`(p b b)` is a type; `pbb` is an argument of type `p b b`, not the type itself.
