### PR TITLE
Fix Challenge 2 in Section 2.3: Use "positive integers" instead of "integers" for monoid under multiplication

### DIFF
--- a/src/content/2.3/free-monoids.tex
+++ b/src/content/2.3/free-monoids.tex
@@ -258,8 +258,8 @@ h a * h e = h (a * e) = h a
         between monoids that preserves multiplication must automatically
         preserve unit.
   \item
-        Consider a monoid homomorphism from lists of integers with
-        concatenation to integers with multiplication. What is the image of
+        Consider a monoid homomorphism from lists of positive integers with
+        concatenation to positive integers with multiplication. What is the image of
         the empty list \code{{[}{]}}? Assume that all singleton lists are
         mapped to the integers they contain, that is \code{{[}3{]}} is
         mapped to 3, etc. What's the image of \code{{[}1, 2, 3, 4{]}}?


### PR DESCRIPTION
This pull request updates Challenge 2 in Section 2.3 (Free Monoids) by replacing "integers" with "positive integers" for the following reason:

The set of all integers (which includes 0) is not a monoid under multiplication.

While 1 serves as an identity element, the presence of 0 breaks the unit law.

To form a valid monoid under multiplication, we must exclude 0. The set of positive integers satisfies the monoid laws with multiplication as the binary operation and 1 as the identity.