### PR TITLE
fix: functor from Kleisli to underlying category

### DIFF
--- a/src/content/3.9/algebras-for-monads.tex
+++ b/src/content/3.9/algebras-for-monads.tex
@@ -298,7 +298,7 @@ on a morphism $f_{\cat{K}}$ corresponding to a Kleisli arrow:
 is a morphism in $\cat{C}$:
 \[T a \to T b\]
 given by first lifting $f$ and then applying $\mu$:
-\[\mu_{T b} \circ T f\]
+\[\mu_{b} \circ T f\]
 In Haskell notation this would read:
 
 \begin{snipv}


### PR DESCRIPTION
Since $f :: a \to T b$ and $\mu :: T^2 \to T$ are given,

```math
Ta \xrightarrow{Tf} T^2b \xrightarrow{\mu_b} Tb
```
is appropriate.

