### PR TITLE
3.10: Denominator must be non-zero

### DIFF
--- a/src/content/3.10/ends-and-coends.tex
+++ b/src/content/3.10/ends-and-coends.tex
@@ -343,8 +343,8 @@ is reflexive, symmetric, and transitive:
 Such a relation splits the set into equivalence classes. Each class
 consists of elements that are related to each other. We form a quotient
 set by picking one representative from each class. A classic example is
-the definition of rational numbers as pairs of whole numbers with the
-following equivalence relation:
+the definition of rational numbers as pairs of whole numbers, second of
+which is non-zero, with the following equivalence relation:
 \[(a, b) \sim (c, d)\ \text{iff}\ a * d = b * c\]
 It's easy to check that this is an equivalence relation. A pair
 $(a, b)$ is interpreted as a fraction $\frac{a}{b}$, and


### PR DESCRIPTION
In the definition of rational numbers, denominator must be non-zero.