### PR TITLE
Use \odot or \circ for composition

### DIFF
--- a/src/content/3.11/kan-extensions.tex
+++ b/src/content/3.11/kan-extensions.tex
@@ -67,7 +67,7 @@ $D$.
 If the Kan extension $F = Ran_{K}D$ exists, there must be a unique
 natural transformation $\sigma$ from $F'$ to it, such
 that $\varepsilon'$ factorizes through $\varepsilon$, that is:
-\[\varepsilon' = \varepsilon\ .\ (\sigma \circ K)\]
+\[\varepsilon' = \varepsilon \cdot (\sigma \circ K)\]
 Here, $\sigma \circ K$ is the horizontal composition of two natural
 transformations (one of them being the identity natural transformation
 on $K$). This transformation is then vertically composed with
@@ -104,7 +104,7 @@ a natural transformation
 there is a unique natural transformation
 \[\sigma \Colon F' \to F\]
 that factorizes $\varepsilon'$:
-\[\varepsilon' = \varepsilon\ .\ (\sigma \circ K)\]
+\[\varepsilon' = \varepsilon \cdot (\sigma \circ K)\]
 This is quite a mouthful, but it can be visualized in this nice diagram:
 
 \begin{figure}[H]
@@ -238,7 +238,7 @@ there is a unique natural transformation $\sigma$ from $F$ to $F'$
 
 \noindent
 such that:
-\[\eta' = (\sigma \circ K)\ .\ \eta\]
+\[\eta' = (\sigma \circ K) \cdot \eta\]
 This is illustrated in the following diagram:
 
 \begin{figure}[H]
@@ -263,7 +263,7 @@ is called the unit of the left Kan extension.
 
 As before, we can recast the one-to-one correspondence between natural
 transformations:
-\[\eta' = (\sigma \circ K)\ .\ \eta\]
+\[\eta' = (\sigma \circ K) \cdot \eta\]
 in terms of the adjunction:
 \[[\cat{A}, \cat{C}](\Lan_{K}D, F') \cong [\cat{I}, \cat{C}](D, F' \circ K)\]
 In other words, the left Kan extension is the left adjoint, and the

--- a/src/content/3.12/enriched-categories.tex
+++ b/src/content/3.12/enriched-categories.tex
@@ -397,7 +397,7 @@ We can follow it with the counit of the adjunction $\varepsilon_{a b}$:
 \[[b, c] \otimes ([a, b] \otimes a) \to [b, c] \otimes b\]
 And use the counit $\varepsilon_{b c}$ again to get to $c$. We have
 thus constructed a morphism:
-\[\varepsilon_{b c}\ .\ (\idarrow[{[b, c]}] \otimes \varepsilon_{a b})\ .\ \alpha_{[b, c] [a, b] a}\]
+\[\varepsilon_{b c} \circ (\idarrow[{[b, c]}] \otimes \varepsilon_{a b}) \circ \alpha_{[b, c] [a, b] a}\]
 that is an element of the hom-set:
 \[\cat{V}(([b, c] \otimes [a, b]) \otimes a, c)\]
 The adjunction will give us the composition law we were looking for.

--- a/src/content/3.13/topoi.tex
+++ b/src/content/3.13/topoi.tex
@@ -58,7 +58,7 @@ their domains. More precisely, we say that two injective functions:
 are equivalent if there is an isomorphism:
 \[h \Colon a \to a'\]
 such that:
-\[f = f'\ .\ h\]
+\[f = f' \circ h\]
 Such a family of equivalent injections defines a subset of $b$.
 
 \begin{figure}[H]
@@ -76,7 +76,7 @@ universal property. For any object $c$ and any pair of morphisms:
   g' & \Colon c \to a
 \end{align*}
 such that:
-\[m\ .\ g = m\ .\ g'\]
+\[m \circ g = m \circ g'\]
 it must be that $g = g'$.
 
 \begin{figure}[H]
@@ -142,8 +142,8 @@ pullback diagram:
 
 \noindent
 Let's analyze this diagram. The pullback equation is:
-\[\mathit{true}\ .\ \mathit{unit} = \chi\ .\ f\]
-The function $\mathit{true}\ .\ \mathit{unit}$ maps every element of $a$ to
+\[\mathit{true} \circ \mathit{unit} = \chi \circ f\]
+The function $\mathit{true} \circ \mathit{unit}$ maps every element of $a$ to
 ``true.'' Therefore $f$ must map all elements of $a$ to
 those elements of $b$ for which $\chi$ is ``true.'' These
 are, by definition, the elements of the subset that is specified by the


### PR DESCRIPTION
I found that some of composition signs are simple dot ($.$), but functors/morphisms compositions should be written as a circle ($\circ$) and vertical compositions of natural transformations should be center dot ($\cdot$).