### PR TITLE
fix: Diagram is too wide for 148mm page width

### DIFF
--- a/src/content/3.12/enriched-categories.tex
+++ b/src/content/3.12/enriched-categories.tex
@@ -185,7 +185,7 @@ $\cat{V}$:
 
 \begin{figure}[H]
   \centering
-  \begin{tikzcd}[column sep=large]
+  \begin{tikzcd}
     (\cat{C}(c,d) \otimes \cat{C}(b,c)) \otimes \cat{C}(a,b)
     \arrow[r, "\circ\otimes\id"]
     \arrow[dd, "\alpha"]


### PR DESCRIPTION
P. 426 of ctfp--98b71ac.pdf:

<img width="611" height="234" alt="スクリーンショット 2025-09-14 17 28 34" src="https://github.com/user-attachments/assets/cf3103ee-bce8-4fce-8fa6-25cf442dc798" />
