### PR TITLE
Replace `I` with `Identity` in Haskell code in 3.11

### DIFF
--- a/src/content/3.11/code/haskell/snippet07.hs
+++ b/src/content/3.11/code/haskell/snippet07.hs
@@ -1,1 +1,1 @@
-type Exp a b = Lan ((,) a) I b
+type Exp a b = Lan ((,) a) Identity b

--- a/src/content/3.11/code/haskell/snippet08.hs
+++ b/src/content/3.11/code/haskell/snippet08.hs
@@ -1,5 +1,5 @@
 toExp :: (a -> b) -> Exp a b
-toExp f = Lan (f . fst) (I ())
+toExp f = Lan (f . fst) (Identity ())
 
 fromExp :: Exp a b -> (a -> b)
-fromExp (Lan f (I x)) = \a -> f (a, x)
+fromExp (Lan f (Identity x)) = \a -> f (a, x)


### PR DESCRIPTION
This is the first time the `I` has been used as identity functor in Haskell code, but we already defined the `Identity` in 1.8.
It is also defined in base library: https://hackage.haskell.org/package/base-4.21.0.0/docs/Data-Functor-Identity.html