### PR TITLE
Use mappend/mempty instead of ++/""

### DIFF
--- a/src/content/1.4/code/haskell/snippet04.hs
+++ b/src/content/1.4/code/haskell/snippet04.hs
@@ -1,4 +1,4 @@
 m1 >=> m2 = \x ->
     let (y, s1) = m1 x
         (z, s2) = m2 y
-    in (z, s1 ++ s2)
+    in (z, s1 `mappend` s2)

--- a/src/content/1.4/code/haskell/snippet05.hs
+++ b/src/content/1.4/code/haskell/snippet05.hs
@@ -1,2 +1,2 @@
 return :: a -> Writer a
-return x = (x, "")
+return x = (x, mempty)


### PR DESCRIPTION
As in previous section in the same chapter:

> An astute reader may notice that it would be easy to generalize this
construction to any monoid, not just the string monoid. We would use
mappend inside compose and mempty inside identity (in place of + and
""). There really is no reason to limit ourselves to logging just strings.
A good library writer should be able to identify the bare minimum of
constraints that make the library work