### PR TITLE
3.9 - Add missing "Suppose that"

### DIFF
--- a/src/content/3.9/algebras-for-monads.tex
+++ b/src/content/3.9/algebras-for-monads.tex
@@ -75,7 +75,8 @@ We can also express these conditions in Haskell:
 \src{snippet01}
 Let's look at a small example. An algebra for a list endofunctor
 consists of some type \code{a} and a function that produces an
-\code{a} from a list of \code{a}. We can express this function using
+\code{a} from a list of \code{a}.
+Suppose that we can express this function using
 \code{foldr} by choosing both the element type and the accumulator
 type to be equal to \code{a}:
 


### PR DESCRIPTION
The function cannot be expressed using `foldr` in general. See https://bartoszmilewski.com/2017/03/14/algebras-for-monads/#comment-220488

fix #386 