### PR TITLE
fix: Format the log formula on a separate line

### DIFF
--- a/src/content/2.4/representable-functors.tex
+++ b/src/content/2.4/representable-functors.tex
@@ -272,7 +272,9 @@ hom-sets can internally be treated as exponential objects, in Cartesian
 closed categories. The hom-set $\cat{C}(a, x)$ is equivalent to
 $x^a$, and for a representable functor $F$ we can write: $-^a = F$.
 
-Let's take the logarithm of both sides, just for kicks: $a = \mathbf{log}F$
+Let's take the logarithm of both sides, just for kicks:
+
+\[a = \log F\]
 
 Of course, this is a purely formal transformation, but if you know some
 of the properties of logarithms, it is quite helpful. In particular, it


### PR DESCRIPTION
This equation should be placed in separate line as in the original blog post. 
Also, you can write it using LaTeX math `\log`.

<img width="577" height="57" alt="スクリーンショット 2026-03-14 17 44 29" src="https://github.com/user-attachments/assets/2eaa41c0-9edf-429e-b5db-76c24fd0cb44" />
